### PR TITLE
Persist password setting

### DIFF
--- a/lib/features/settings/controller/settings_controller.dart
+++ b/lib/features/settings/controller/settings_controller.dart
@@ -219,5 +219,11 @@ class SettingsController {
     return '${dateTime.year}${twoDigits(dateTime.month)}${twoDigits(dateTime.day)}_${twoDigits(dateTime.hour)}${twoDigits(dateTime.minute)}${twoDigits(dateTime.second)}';
   }
 
-  Future<void> saveUsePasswordSetting(bool value) async {}
+  Future<void> saveUsePasswordSetting(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_usePasswordKey, value);
+    if (kDebugMode) {
+      print('Saved usePassword: $value');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- implement `saveUsePasswordSetting` in `SettingsController`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac3b0f7f88329a7d405341078486b