### PR TITLE
Fix pin verification header comment

### DIFF
--- a/lib/features/settings/presentation/screens/pin_verification_screen.dart
+++ b/lib/features/settings/presentation/screens/pin_verification_screen.dart
@@ -1,4 +1,4 @@
-// pin_verification_gate.dart
+// pin_verification_screen.dart
 import 'package:contactsafe/features/settings/controller/settings_controller.dart';
 import 'package:contactsafe/features/settings/presentation/screens/pin_dialog.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Summary
- correct the header comment for the PIN verification screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac4108d1c8329ac1e1368f2036552