### PR TITLE
Update widget test for Contacts screen

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,29 +1,13 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Basic widget test for ContactSafeApp.
+// Pumps the app and verifies the Contacts screen loads.
 
 import 'package:contactsafe/app.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(ContactSafeApp());
+  testWidgets('Contacts screen loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const ContactSafeApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Contacts'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- rewrite widget test to pump `ContactSafeApp`
- ensure we can find the `Contacts` title on startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac3be34e08329988ca15e5ce1aeea