### PR TITLE
Allow longer phone numbers

### DIFF
--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
+import 'package:flutter/services.dart';
 import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart'; // <<< ADD THIS IMPORT
 
@@ -425,6 +426,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
                           ),
                         ),
                         initialCountryCode: 'US',
+                        inputFormatters: const [
+                          LengthLimitingTextInputFormatter(20),
+                        ],
                         onChanged: (phone) {
                           _phoneNumbers[index] = phone.number;
                         },

--- a/lib/features/contacts/presentation/screens/edit_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/edit_contact_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
+import 'package:flutter/services.dart';
 import 'dart:typed_data';
 import 'package:permission_handler/permission_handler.dart';
 
@@ -459,6 +460,9 @@ class _EditContactScreenState extends State<EditContactScreen> {
                           ),
                         ),
                         initialCountryCode: 'US',
+                        inputFormatters: const [
+                          LengthLimitingTextInputFormatter(20),
+                        ],
                         onChanged: (phone) {
                           _phoneNumbers[index] = phone.number;
                         },


### PR DESCRIPTION
## Summary
- allow up to 20 digits in phone fields

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c395ba5b883299a85019c18014ac9