### PR TITLE
Add file and note management features

### DIFF
--- a/lib/features/contacts/presentation/screens/contact_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:contactsafe/features/contacts/presentation/screens/edit_contact_screen.dart';
 
@@ -36,12 +37,27 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
   }
 
   Future<void> _loadCounts() async {
-    // final files = await YourFileService.getCount(widget.contact.id);
-    // final notes = await YourNoteService.getCount(widget.contact.id);
-    setState(() {
-      _filesCount = 3; // Example count - replace with real implementation
-      _notesCount = 2; // Example count - replace with real implementation
-    });
+    try {
+      final filesSnapshot = await FirebaseFirestore.instance
+          .collection('contact_files_metadata')
+          .doc(widget.contact.id)
+          .collection('files')
+          .get();
+      final notesSnapshot = await FirebaseFirestore.instance
+          .collection('contact_notes')
+          .doc(widget.contact.id)
+          .collection('notes')
+          .get();
+      setState(() {
+        _filesCount = filesSnapshot.size;
+        _notesCount = notesSnapshot.size;
+      });
+    } catch (e) {
+      setState(() {
+        _filesCount = 0;
+        _notesCount = 0;
+      });
+    }
   }
 
   Future<void> _loadContactDetails(String contactId) async {

--- a/lib/features/contacts/presentation/screens/note_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/note_detail_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import 'contact_notes_screen.dart';
+
+class NoteDetailScreen extends StatelessWidget {
+  final ContactNote note;
+  const NoteDetailScreen({super.key, required this.note});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Note'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: () => Navigator.pop(context, 'delete'),
+          ),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () => Navigator.pop(context, note.content),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(
+          note.content,
+          style: const TextStyle(fontSize: 16),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- enable picking any file type
- add rename, share, and delete options for contact files
- implement Firestore-backed notes with detail screen
- display real counts of files and notes in contact detail

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b7896f88329b8c370fef9c75f3a