### PR TITLE
Filter events per user and update add event dialog

### DIFF
--- a/lib/features/events/data/models/event_model.dart
+++ b/lib/features/events/data/models/event_model.dart
@@ -9,6 +9,7 @@ class AppEvent {
   location; // Stores either an address string or coordinates string
   final String? description;
   final List<String> participantContactIds; // Store only Contact IDs
+  final String userId; // Owner of the event
 
   AppEvent({
     this.id,
@@ -17,6 +18,7 @@ class AppEvent {
     this.location,
     this.description,
     required this.participantContactIds,
+    required this.userId,
   });
 
   // Factory constructor to create an AppEvent from a Firestore document
@@ -34,6 +36,7 @@ class AppEvent {
       participantContactIds: List<String>.from(
         data?['participantContactIds'] ?? [],
       ),
+      userId: data?['userId'] ?? '',
     );
   }
 
@@ -45,6 +48,7 @@ class AppEvent {
       'location': location,
       'description': description,
       'participantContactIds': participantContactIds,
+      'userId': userId,
     };
   }
 

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 import 'package:contactsafe/features/events/data/models/event_model.dart';
 import 'package:contactsafe/features/events/presentation/screens/events_detail_screen.dart';
@@ -111,9 +112,11 @@ class _SearchScreenState extends State<SearchScreen> {
         );
       }).toList();
 
-      // Fetch events
+      // Fetch events for the current user
+      final uid = FirebaseAuth.instance.currentUser?.uid;
       final eventSnapshot = await FirebaseFirestore.instance
           .collection('events')
+          .where('userId', isEqualTo: uid)
           .withConverter(
             fromFirestore: AppEvent.fromFirestore,
             toFirestore: (AppEvent event, options) => event.toFirestore(),


### PR DESCRIPTION
## Summary
- associate events with the logged in user
- show only the current user's events
- include user filtering in global search
- restyle the new event dialog to match the app theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c487e6b4483299e875904cefcf0ed