### PR TITLE
Implement local event storage

### DIFF
--- a/lib/features/events/data/local_event_repository.dart
+++ b/lib/features/events/data/local_event_repository.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'models/event_model.dart';
+
+class LocalEventRepository {
+  Future<File> _getEventsFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/events.json');
+  }
+
+  Future<List<AppEvent>> loadEvents() async {
+    final file = await _getEventsFile();
+    if (!await file.exists()) return [];
+    final jsonString = await file.readAsString();
+    if (jsonString.isEmpty) return [];
+    final List<dynamic> data = jsonDecode(jsonString);
+    return data
+        .map((e) => AppEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveEvents(List<AppEvent> events) async {
+    final file = await _getEventsFile();
+    final data = events.map((e) => e.toJson()).toList();
+    await file.writeAsString(jsonEncode(data));
+  }
+
+  Future<void> addEvent(AppEvent event) async {
+    final events = await loadEvents();
+    events.add(event);
+    await saveEvents(events);
+  }
+}

--- a/lib/features/events/data/models/event_model.dart
+++ b/lib/features/events/data/models/event_model.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter_contacts/contact.dart';
+import 'package:flutter_contacts/flutter_contacts.dart';
 
 class AppEvent {
   final String? id; // Firestore document ID
@@ -9,7 +9,7 @@ class AppEvent {
   location; // Stores either an address string or coordinates string
   final String? description;
   final List<String> participantContactIds; // Store only Contact IDs
-  final String userId; // Owner of the event
+  final String userId; // Owner of the event (unused for local storage)
 
   AppEvent({
     this.id,
@@ -45,6 +45,31 @@ class AppEvent {
     return {
       'title': title,
       'date': Timestamp.fromDate(date),
+      'location': location,
+      'description': description,
+      'participantContactIds': participantContactIds,
+      'userId': userId,
+    };
+  }
+
+  factory AppEvent.fromJson(Map<String, dynamic> json) {
+    return AppEvent(
+      id: json['id'] as String?,
+      title: json['title'] as String? ?? 'No Title',
+      date: DateTime.parse(json['date'] as String),
+      location: json['location'] as String?,
+      description: json['description'] as String?,
+      participantContactIds:
+          List<String>.from(json['participantContactIds'] ?? const []),
+      userId: json['userId'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'date': date.toIso8601String(),
       'location': location,
       'description': description,
       'participantContactIds': participantContactIds,

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:contactsafe/features/events/data/local_event_repository.dart';
 import 'package:intl/intl.dart';
 import 'package:contactsafe/features/events/data/models/event_model.dart';
 import 'package:contactsafe/features/events/presentation/screens/events_detail_screen.dart';
@@ -112,17 +112,8 @@ class _SearchScreenState extends State<SearchScreen> {
         );
       }).toList();
 
-      // Fetch events for the current user
-      final uid = FirebaseAuth.instance.currentUser?.uid;
-      final eventSnapshot = await FirebaseFirestore.instance
-          .collection('events')
-          .where('userId', isEqualTo: uid)
-          .withConverter(
-            fromFirestore: AppEvent.fromFirestore,
-            toFirestore: (AppEvent event, options) => event.toFirestore(),
-          )
-          .get();
-      final events = eventSnapshot.docs.map((doc) => doc.data()).toList();
+      // Load events from local storage
+      final events = await LocalEventRepository().loadEvents();
 
       setState(() {
         _allFiles = files;


### PR DESCRIPTION
## Summary
- add a simple local repository to store events in a JSON file
- convert `AppEvent` to/from JSON
- update events screen to load/save events locally
- update search screen to read events from local storage

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d405e388329adcf77def9d8a822