### PR TITLE
Implement basic language and sorting settings

### DIFF
--- a/lib/features/contacts/presentation/provider/contacts_provider.dart
+++ b/lib/features/contacts/presentation/provider/contacts_provider.dart
@@ -1,6 +1,11 @@
 import 'package:flutter_contacts/flutter_contacts.dart';
 
 class ContactsProvider {
+  final bool sortByFirstName;
+  final bool lastNameFirst;
+
+  ContactsProvider({this.sortByFirstName = false, this.lastNameFirst = false});
+
   List<Contact> _contacts = [];
   List<Contact> _allContacts = [];
 
@@ -16,7 +21,15 @@ class ContactsProvider {
           withPhoto: true,
           withAccounts: true,
         );
-        contacts.sort((a, b) => a.displayName.compareTo(b.displayName));
+        contacts.sort((a, b) {
+          String keyA = sortByFirstName
+              ? a.name.first
+              : (a.name.last.isNotEmpty ? a.name.last : a.displayName);
+          String keyB = sortByFirstName
+              ? b.name.first
+              : (b.name.last.isNotEmpty ? b.name.last : b.displayName);
+          return keyA.compareTo(keyB);
+        });
         _contacts = contacts;
         _allContacts = List.from(contacts);
       }
@@ -44,8 +57,11 @@ class ContactsProvider {
   Map<String, List<Contact>> groupContacts(List<Contact> contacts) {
     final Map<String, List<Contact>> groupedContacts = {};
     for (final contact in contacts) {
-      if (contact.displayName.isNotEmpty) {
-        final firstLetter = contact.displayName[0].toUpperCase();
+      final String displayName = lastNameFirst && contact.name.last.isNotEmpty
+          ? '${contact.name.last} ${contact.name.first}'
+          : contact.displayName;
+      if (displayName.isNotEmpty) {
+        final firstLetter = displayName[0].toUpperCase();
         groupedContacts.putIfAbsent(firstLetter, () => []).add(contact);
       }
     }

--- a/lib/features/contacts/presentation/screens/contacts_screen.dart
+++ b/lib/features/contacts/presentation/screens/contacts_screen.dart
@@ -1,5 +1,6 @@
 import 'package:contactsafe/features/contacts/presentation/provider/contacts_provider.dart';
 import 'package:contactsafe/features/contacts/presentation/widgets/contact_list_widget.dart';
+import 'package:contactsafe/features/settings/controller/settings_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:contactsafe/features/contacts/presentation/screens/contact_group_screen.dart';
 import 'package:contactsafe/features/contacts/presentation/screens/AssignContactsToGroupScreen.dart'
@@ -20,14 +21,27 @@ class _ContactsScreenState extends State<ContactsScreen> {
   int _currentIndex = 0;
   final TextEditingController _searchController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
-  final ContactsProvider _contactsProvider = ContactsProvider();
+  late ContactsProvider _contactsProvider;
   final List<String> _selectedGroups = [];
   List<Contact> _displayedContacts = [];
+  final SettingsController _settingsController = SettingsController();
+  bool _lastNameFirst = false;
+  bool _sortByFirstName = false;
 
   @override
   void initState() {
     super.initState();
-    _loadContacts();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    _sortByFirstName = await _settingsController.loadSortByFirstName();
+    _lastNameFirst = await _settingsController.loadLastNameFirst();
+    _contactsProvider = ContactsProvider(
+      sortByFirstName: _sortByFirstName,
+      lastNameFirst: _lastNameFirst,
+    );
+    await _loadContacts();
   }
 
   Future<void> _loadContacts() async {
@@ -257,6 +271,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
                       );
                     },
                     onLetterTap: _scrollToLetter,
+                    lastNameFirst: _lastNameFirst,
                   ),
                 ),
               ),

--- a/lib/features/contacts/presentation/widgets/contact_list_widget.dart
+++ b/lib/features/contacts/presentation/widgets/contact_list_widget.dart
@@ -6,6 +6,7 @@ class ContactListWidget extends StatelessWidget {
   final ScrollController scrollController;
   final Function(Contact) onContactTap;
   final Function(String) onLetterTap;
+  final bool lastNameFirst;
 
   const ContactListWidget({
     super.key,
@@ -13,6 +14,7 @@ class ContactListWidget extends StatelessWidget {
     required this.scrollController,
     required this.onContactTap,
     required this.onLetterTap,
+    required this.lastNameFirst,
   });
 
   @override
@@ -81,6 +83,7 @@ class ContactListWidget extends StatelessWidget {
                         return ContactListItem(
                           contact: contact,
                           onTap: () => onContactTap(contact),
+                          lastNameFirst: lastNameFirst,
                         );
                       },
                       separatorBuilder:
@@ -143,8 +146,11 @@ class ContactListWidget extends StatelessWidget {
   Map<String, List<Contact>> _groupContacts(List<Contact> contacts) {
     final Map<String, List<Contact>> groupedContacts = {};
     for (final contact in contacts) {
-      if (contact.displayName.isNotEmpty) {
-        final firstLetter = contact.displayName[0].toUpperCase();
+      final String displayName = lastNameFirst && contact.name.last.isNotEmpty
+          ? '${contact.name.last} ${contact.name.first}'
+          : contact.displayName;
+      if (displayName.isNotEmpty) {
+        final firstLetter = displayName[0].toUpperCase();
         groupedContacts.putIfAbsent(firstLetter, () => []).add(contact);
       }
     }
@@ -155,11 +161,13 @@ class ContactListWidget extends StatelessWidget {
 class ContactListItem extends StatelessWidget {
   final Contact contact;
   final VoidCallback onTap;
+  final bool lastNameFirst;
 
   const ContactListItem({
     super.key,
     required this.contact,
     required this.onTap,
+    required this.lastNameFirst,
   });
 
   @override
@@ -179,7 +187,9 @@ class ContactListItem extends StatelessWidget {
               const SizedBox(width: 16),
               Expanded(
                 child: Text(
-                  contact.displayName,
+                  lastNameFirst && contact.name.last.isNotEmpty
+                      ? '${contact.name.last} ${contact.name.first}'
+                      : contact.displayName,
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w400,
@@ -225,8 +235,14 @@ class ContactListItem extends StatelessWidget {
                   ),
                 )
                 : Text(
-                  contact.displayName.isNotEmpty
-                      ? contact.displayName[0].toUpperCase()
+                  (lastNameFirst && contact.name.last.isNotEmpty
+                          ? '${contact.name.last} ${contact.name.first}'
+                          : contact.displayName)
+                      .isNotEmpty
+                      ? (lastNameFirst && contact.name.last.isNotEmpty
+                              ? contact.name.last[0]
+                              : contact.displayName[0])
+                          .toUpperCase()
                       : '',
                   style: TextStyle(
                     fontSize: 16,

--- a/lib/features/settings/controller/settings_controller.dart
+++ b/lib/features/settings/controller/settings_controller.dart
@@ -20,6 +20,9 @@ class SettingsController {
       'usePassword': prefs.getBool('usePassword') ?? false,
       'useFaceId': prefs.getBool('useFaceId') ?? false,
       'tabBarOrder': await _loadTabBarOrder(prefs),
+      'language': prefs.getString('language') ?? 'en',
+      'sortByFirstName': prefs.getBool('sortByFirstName') ?? false,
+      'lastNameFirst': prefs.getBool('lastNameFirst') ?? false,
     };
   }
 
@@ -58,6 +61,36 @@ class SettingsController {
     if (kDebugMode) {
       print('Saved useFaceId: $value');
     }
+  }
+
+  Future<void> saveLanguage(String language) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('language', language);
+  }
+
+  Future<String> loadLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('language') ?? 'en';
+  }
+
+  Future<void> saveSortByFirstName(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('sortByFirstName', value);
+  }
+
+  Future<bool> loadSortByFirstName() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('sortByFirstName') ?? false;
+  }
+
+  Future<void> saveLastNameFirst(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('lastNameFirst', value);
+  }
+
+  Future<bool> loadLastNameFirst() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('lastNameFirst') ?? false;
   }
 
   // Load TabBar order
@@ -120,8 +153,12 @@ class SettingsController {
   Future<String> createBackup() async {
     try {
       final directory = await getApplicationDocumentsDirectory();
+      final backupDir = Directory('${directory.path}/ContactSafe');
+      if (!await backupDir.exists()) {
+        await backupDir.create(recursive: true);
+      }
       final String filePath =
-          '${directory.path}/contactsafe_backup_${_formatDateTime(DateTime.now())}.json';
+          '${backupDir.path}/backup_${_formatDateTime(DateTime.now())}.json';
       final File file = File(filePath);
 
       final List<Map<String, dynamic>> dummyContactsData = [

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -22,6 +22,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _lastNameFirst = false;
   bool _usePass = false;
   bool _useFaceId = false;
+  String _currentLanguage = 'en';
   List<NavigationItem> _navigationItems = NavigationItem.defaultItems();
   final SettingsController _controller = SettingsController();
 
@@ -38,6 +39,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _useFaceId = settings['useFaceId'] ?? false;
       _navigationItems =
           settings['tabBarOrder'] ?? NavigationItem.defaultItems();
+      _currentLanguage = settings['language'] ?? 'en';
+      _sortByFirstName = settings['sortByFirstName'] ?? false;
+      _lastNameFirst = settings['lastNameFirst'] ?? false;
     });
   }
 
@@ -242,6 +246,44 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
+  String _languageLabel(String code) {
+    switch (code) {
+      case 'de':
+        return 'German';
+      case 'mn':
+        return 'Mongolian';
+      default:
+        return 'English';
+    }
+  }
+
+  Future<void> _showLanguageDialog() async {
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (context) => SimpleDialog(
+        title: const Text('Select Language'),
+        children: [
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(context, 'en'),
+            child: const Text('English'),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(context, 'de'),
+            child: const Text('German'),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(context, 'mn'),
+            child: const Text('Mongolian'),
+          ),
+        ],
+      ),
+    );
+    if (selected != null) {
+      setState(() => _currentLanguage = selected);
+      await _controller.saveLanguage(selected);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -330,20 +372,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               SettingsTile.navigation(
                 title: const Text('Language'),
-                trailing: Icon(
-                  Icons.chevron_right,
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withOpacity(0.4),
+                trailing: Text(
+                  _languageLabel(_currentLanguage),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                  ),
                 ),
-                onPressed: (context) {
-                  // TODO: Implement language selection
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Language selection coming soon!'),
-                    ),
-                  );
-                },
+                onPressed: (context) => _showLanguageDialog(),
               ),
             ],
           ),
@@ -409,12 +444,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               SettingsTile.switchTile(
                 title: const Text('Sort by first name'),
                 initialValue: _sortByFirstName,
-                onToggle: (value) => setState(() => _sortByFirstName = value),
+                onToggle: (value) async {
+                  setState(() => _sortByFirstName = value);
+                  await _controller.saveSortByFirstName(value);
+                },
               ),
               SettingsTile.switchTile(
                 title: const Text('Last name first'),
                 initialValue: _lastNameFirst,
-                onToggle: (value) => setState(() => _lastNameFirst = value),
+                onToggle: (value) async {
+                  setState(() => _lastNameFirst = value);
+                  await _controller.saveLastNameFirst(value);
+                },
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- add persistent language and contact display settings
- allow sorting by first name or last name
- show last name first option in contact list
- create backups in a ContactSafe folder

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c54f735208329ad79f9eddfe036c7