### PR TITLE
Add widget and unit tests for core screens

### DIFF
--- a/test/events_test.dart
+++ b/test/events_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:contactsafe/features/events/data/local_event_repository.dart';
+import 'package:contactsafe/features/events/data/models/event_model.dart';
+import 'package:contactsafe/features/events/presentation/screens/events_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+        return tempDir.path;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    channel.setMockMethodCallHandler(null);
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('Events screen loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: EventsScreen()));
+    expect(find.text('Events'), findsOneWidget);
+  });
+
+  test('LocalEventRepository saves and loads events', () async {
+    final repo = LocalEventRepository();
+    final event = AppEvent(
+      title: 'Test',
+      date: DateTime(2024, 1, 1),
+      location: 'here',
+      description: 'desc',
+      participantContactIds: const [],
+      userId: '1',
+    );
+
+    await repo.saveEvents([event]);
+    final events = await repo.loadEvents();
+
+    expect(events.length, 1);
+    expect(events.first.title, 'Test');
+  });
+}

--- a/test/search_test.dart
+++ b/test/search_test.dart
@@ -1,0 +1,10 @@
+import 'package:contactsafe/features/search/presentation/screens/search_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Search screen loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SearchScreen()));
+    expect(find.text('Search'), findsOneWidget);
+  });
+}

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -1,0 +1,25 @@
+import 'package:contactsafe/features/settings/controller/settings_controller.dart';
+import 'package:contactsafe/features/settings/presentation/screens/settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Settings screen loads', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsScreen()));
+    expect(find.text('Settings'), findsOneWidget);
+  });
+
+  test('SettingsController pin operations', () async {
+    SharedPreferences.setMockInitialValues({});
+    final controller = SettingsController();
+
+    await controller.savePin('1234');
+    expect(await controller.verifyPin('1234'), isTrue);
+    expect(await controller.hasPinEnabled(), isTrue);
+    await controller.deletePin();
+    expect(await controller.hasPin(), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget tests for events, settings, and search screens
- test `LocalEventRepository` read/write
- test `SettingsController` PIN operations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d601be3c88329992dcd5c1de3c5ab