### PR TITLE
Replace print statements with debugPrint

### DIFF
--- a/lib/features/contacts/presentation/provider/contacts_provider.dart
+++ b/lib/features/contacts/presentation/provider/contacts_provider.dart
@@ -34,7 +34,7 @@ class ContactsProvider {
         _allContacts = List.from(contacts);
       }
     } catch (e) {
-      print('Error requesting contact permission: $e');
+      debugPrint('Error requesting contact permission: $e');
       rethrow;
     }
   }

--- a/lib/features/contacts/presentation/screens/AssignContactsToGroupScreen.dart
+++ b/lib/features/contacts/presentation/screens/AssignContactsToGroupScreen.dart
@@ -119,10 +119,10 @@ class _AssignContactsToGroupScreenState
     // -----------------------------------------------------
 
     // Optional: Print updated map for verification
-    print('Updated Group Assignments for "${widget.groupName}":');
+    debugPrint('Updated Group Assignments for "${widget.groupName}":');
     globalContactGroupsMap.forEach((contactName, groups) {
       if (groups.contains(widget.groupName)) {
-        print('- $contactName is now in "${widget.groupName}"');
+        debugPrint('- $contactName is now in "${widget.groupName}"');
       }
     });
 

--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -184,7 +184,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       }
     } catch (e) {
       if (mounted) {
-        print('Error saving contact to device or Firestore: $e');
+        debugPrint('Error saving contact to device or Firestore: $e');
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text('Failed to save contact: $e')));

--- a/lib/features/contacts/presentation/screens/contact_files_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_files_screen.dart
@@ -96,7 +96,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
   void initState() {
     super.initState();
     // Log the contact ID to ensure it's valid
-    print('Loading files for contact ID: ${widget.contact.id}');
+    debugPrint('Loading files for contact ID: ${widget.contact.id}');
     _loadFiles();
   }
 
@@ -128,7 +128,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
         _sortFiles();
       });
     } catch (e) {
-      print('Error loading files: $e');
+      debugPrint('Error loading files: $e');
       _showSnackBar('Failed to load files: ${e.toString()}'); // Show full error
     } finally {
       setState(() {
@@ -168,15 +168,15 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
             final ref = _storage.ref().child(storagePath);
 
             // 1. Upload file to Firebase Storage
-            print('Attempting to upload ${fileName} to Storage...');
+            debugPrint('Attempting to upload ${fileName} to Storage...');
             await ref.putData(platformFile.bytes!);
             final downloadUrl = await ref.getDownloadURL();
-            print(
+            debugPrint(
               'Successfully uploaded ${fileName} to Storage. Download URL: $downloadUrl',
             );
 
             // 2. Save metadata to Firestore
-            print(
+            debugPrint(
               'Attempting to save metadata for ${fileName} to Firestore...',
             );
             final newFile = ContactFile(
@@ -190,7 +190,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
 
             // Add document to Firestore and get its ID
             final docRef = await _contactFilesCollection().add(newFile);
-            print(
+            debugPrint(
               'Successfully saved metadata for ${fileName} to Firestore. Doc ID: ${docRef.id}',
             );
 
@@ -201,7 +201,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
             });
             successfulUploads++;
           } catch (e) {
-            print(
+            debugPrint(
               'Error uploading or saving metadata for ${platformFile.name}: $e',
             );
             _showSnackBar(
@@ -230,7 +230,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
         _loadFiles(); // Re-fetch the true state from Firestore
       } catch (e) {
         // <--- Corresponding catch block for the outer try
-        print('Overall error during file picking or processing: $e');
+        debugPrint('Overall error during file picking or processing: $e');
         _showSnackBar(
           'An overall error occurred during file picking or processing: ${e.toString()}',
         );
@@ -261,14 +261,14 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                         'File not found locally for ID: $fileId',
                       ), // More robust error
             );
-            print(
+            debugPrint(
               'Attempting to delete ${fileToDelete.name} from Storage and Firestore...',
             );
             // Delete from Firebase Storage
             await _storage.ref().child(fileToDelete.storagePath).delete();
             // Delete metadata from Firestore
             await _contactFilesCollection().doc(fileId).delete();
-            print('Successfully deleted ${fileToDelete.name}.');
+            debugPrint('Successfully deleted ${fileToDelete.name}.');
           }).toList();
 
       await Future.wait(deleteFutures);
@@ -280,7 +280,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
       });
       _showSnackBar('Selected files deleted successfully!');
     } catch (e) {
-      print('Error deleting files: $e');
+      debugPrint('Error deleting files: $e');
       _showSnackBar('Failed to delete selected files: ${e.toString()}');
     } finally {
       setState(() {

--- a/lib/features/events/presentation/screens/events_detail_screen.dart
+++ b/lib/features/events/presentation/screens/events_detail_screen.dart
@@ -50,7 +50,7 @@ class _EventsDetailScreenState extends State<EventsDetailScreen> {
             final lat = double.parse(parts[0].trim());
             final lng = double.parse(parts[1].trim());
             _eventLatLng = LatLng(lat, lng);
-            print('Parsed location directly: $_eventLatLng');
+            debugPrint('Parsed location directly: $_eventLatLng');
           } catch (_) {
             // Not a direct LatLng, proceed to geocoding
           }
@@ -66,16 +66,16 @@ class _EventsDetailScreenState extends State<EventsDetailScreen> {
               locations.first.latitude,
               locations.first.longitude,
             );
-            print('Geocoded location: $_eventLatLng');
+            debugPrint('Geocoded location: $_eventLatLng');
           } else {
-            print('Could not geocode address: ${widget.event.location}');
+            debugPrint('Could not geocode address: ${widget.event.location}');
           }
         }
       } else {
-        print('Event has no location string.');
+        debugPrint('Event has no location string.');
       }
     } catch (e) {
-      print('Error geocoding event location: $e');
+      debugPrint('Error geocoding event location: $e');
     } finally {
       setState(() {
         _isLoadingMap = false;

--- a/lib/features/events/presentation/screens/events_screen.dart
+++ b/lib/features/events/presentation/screens/events_screen.dart
@@ -51,9 +51,9 @@ class _EventsScreenState extends State<EventsScreen> {
             .request(); // Or .location if you need background location
 
     if (status.isGranted) {
-      print('Location permission granted');
+      debugPrint('Location permission granted');
     } else if (status.isDenied) {
-      print('Location permission denied');
+      debugPrint('Location permission denied');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -64,7 +64,7 @@ class _EventsScreenState extends State<EventsScreen> {
         );
       }
     } else if (status.isPermanentlyDenied) {
-      print('Location permission permanently denied');
+      debugPrint('Location permission permanently denied');
       if (mounted) {
         openAppSettings(); // Direct the user to app settings
         ScaffoldMessenger.of(context).showSnackBar(
@@ -81,7 +81,7 @@ class _EventsScreenState extends State<EventsScreen> {
   // Fetches contacts from the device
   Future<void> _fetchContacts() async {
     if (!await FlutterContacts.requestPermission()) {
-      print('Contacts permission denied');
+      debugPrint('Contacts permission denied');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -104,7 +104,7 @@ class _EventsScreenState extends State<EventsScreen> {
         _allContacts = contacts;
       });
     } catch (e) {
-      print('Error fetching contacts: $e');
+      debugPrint('Error fetching contacts: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error fetching contacts: ${e.toString()}')),
@@ -123,7 +123,7 @@ class _EventsScreenState extends State<EventsScreen> {
         _filterEvents(_searchController.text);
       });
     } catch (e) {
-      print("Failed to load events: $e");
+      debugPrint("Failed to load events: $e");
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error loading events: ${e.toString()}')),
@@ -576,7 +576,7 @@ class _EventsScreenState extends State<EventsScreen> {
         currentIndex: _currentIndex,
         onTap: (index) {
           setState(() => _currentIndex = index);
-          print('Bottom navigation tapped: $index');
+          debugPrint('Bottom navigation tapped: $index');
           switch (index) {
             case 0:
               Navigator.pushReplacementNamed(context, '/contacts');

--- a/lib/features/events/presentation/widgets/location_picker_screen.dart
+++ b/lib/features/events/presentation/widgets/location_picker_screen.dart
@@ -77,7 +77,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         }
       }
     } catch (e) {
-      print("Could not get current location: $e");
+      debugPrint("Could not get current location: $e");
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Could not get current location.')),
@@ -109,7 +109,7 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         }
       }
     } catch (e) {
-      print('Error during reverse geocoding: $e');
+      debugPrint('Error during reverse geocoding: $e');
       address = null; // Ensure it's null if geocoding fails
     } finally {
       setState(() {

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -125,7 +125,7 @@ class _SearchScreenState extends State<SearchScreen> {
       setState(() {
         _isLoading = false;
       });
-      print('Error fetching data: $e');
+      debugPrint('Error fetching data: $e');
     }
   }
 

--- a/lib/features/settings/controller/settings_controller.dart
+++ b/lib/features/settings/controller/settings_controller.dart
@@ -62,7 +62,7 @@ class SettingsController {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('useFaceId', value);
     if (kDebugMode) {
-      print('Saved useFaceId: $value');
+      debugPrint('Saved useFaceId: $value');
     }
   }
 
@@ -110,13 +110,13 @@ class SettingsController {
             .toList();
       } catch (e) {
         if (kDebugMode) {
-          print('Error decoding saved TabBar order: $e');
+          debugPrint('Error decoding saved TabBar order: $e');
         }
         return NavigationItem.defaultItems();
       }
     } else {
       if (kDebugMode) {
-        print('No saved TabBar order found, using default.');
+        debugPrint('No saved TabBar order found, using default.');
       }
       return NavigationItem.defaultItems();
     }
@@ -129,7 +129,7 @@ class SettingsController {
         newOrder.map((item) => item.toJson()).toList();
     await prefs.setString('tabBarOrder', jsonEncode(orderToJson));
     if (kDebugMode) {
-      print('Saved TabBar order: ${newOrder.map((e) => e.label).join(', ')}');
+      debugPrint('Saved TabBar order: ${newOrder.map((e) => e.label).join(', ')}');
     }
   }
 
@@ -146,7 +146,7 @@ class SettingsController {
       return 0;
     } catch (e) {
       if (kDebugMode) {
-        print('Error importing contacts: $e');
+        debugPrint('Error importing contacts: $e');
       }
       throw Exception('Failed to import contacts: $e');
     }
@@ -186,7 +186,7 @@ class SettingsController {
       return file.path.split('/').last;
     } catch (e) {
       if (kDebugMode) {
-        print('Error creating backup: $e');
+        debugPrint('Error creating backup: $e');
       }
       throw Exception('Failed to create backup: $e');
     }
@@ -232,7 +232,7 @@ class SettingsController {
       return 0;
     } catch (e) {
       if (kDebugMode) {
-        print('Error restoring backup: $e');
+        debugPrint('Error restoring backup: $e');
       }
       throw Exception('Failed to restore backup: $e');
     }
@@ -364,7 +364,7 @@ class SettingsController {
       return data.length;
     } catch (e) {
       if (kDebugMode) {
-        print('Error importing from link: $e');
+        debugPrint('Error importing from link: $e');
       }
       throw Exception('Failed to import backup from link: $e');
     }
@@ -386,7 +386,7 @@ class SettingsController {
       await prefs.clear();
     } catch (e) {
       if (kDebugMode) {
-        print('Error deleting all data: $e');
+        debugPrint('Error deleting all data: $e');
       }
       throw Exception('Failed to delete all data: $e');
     }
@@ -421,7 +421,7 @@ class SettingsController {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_usePasswordKey, value);
     if (kDebugMode) {
-      print('Saved usePassword: $value');
+      debugPrint('Saved usePassword: $value');
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove direct `print` calls from production code
- use `debugPrint` for logging in screens and controllers

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d64a6c6048329b59759e4af00eb33