### PR TITLE
Replace deprecated color calls

### DIFF
--- a/lib/features/contacts/presentation/screens/AssignContactsToGroupScreen.dart
+++ b/lib/features/contacts/presentation/screens/AssignContactsToGroupScreen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 
@@ -222,7 +223,7 @@ class _AssignContactsToGroupScreenState
                                   contact.thumbnail != null
                                       ? MemoryImage(contact.thumbnail!)
                                       : null,
-                              backgroundColor: Colors.blue.withOpacity(0.7),
+                              backgroundColor: Colors.blue.withValues(alpha: (0.7 * 255).round()),
                               child:
                                   contact.thumbnail == null
                                       ? Text(

--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:image_picker/image_picker.dart';
@@ -381,7 +382,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
             'Phone (${_getPhoneLabelString(_phoneLabels[0])})',
             style: TextStyle(
               fontSize: 12,
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
             ),
           ),
           ListView.builder(
@@ -473,14 +474,14 @@ class _AddContactScreenState extends State<AddContactScreen> {
               },
               icon: Icon(
                 Icons.add_circle_outline,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ), // Grey icon
               label: Text(
                 'Add phone',
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -551,7 +552,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
@@ -701,7 +702,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         Icons.clear,
                         color: Theme.of(
                           context,
-                        ).colorScheme.onSurface.withOpacity(0.6),
+                        ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                       ),
                       onPressed: () {
                         setState(() {
@@ -937,14 +938,14 @@ class _AddContactScreenState extends State<AddContactScreen> {
               onPressed: onAdd,
               icon: Icon(
                 Icons.add_circle_outline,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ), // Grey icon
               label: Text(
                 'Add $label',
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                   fontWeight: FontWeight.w500,
                 ),
               ),

--- a/lib/features/contacts/presentation/screens/contact_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'dart:convert';
 import 'dart:io';
 
@@ -313,7 +314,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+        color: Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Text(
@@ -333,7 +334,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
       height: 120,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+        color: Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
         border: Border.all(color: Colors.blue, width: 2),
       ),
       child:
@@ -375,7 +376,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
               color: Theme.of(context).colorScheme.surface,
               boxShadow: [
                 BoxShadow(
-                  color: Colors.grey.withOpacity(0.1),
+                  color: Colors.grey.withValues(alpha: (0.1 * 255).round()),
                   blurRadius: 4,
                   offset: const Offset(0, 2),
                 ),
@@ -476,7 +477,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
     }
 
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0.5,
@@ -564,7 +565,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                         fontSize: 18,
                         color: Theme.of(
                           context,
-                        ).colorScheme.onSurface.withOpacity(0.6),
+                        ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                         fontWeight: FontWeight.w500,
                       ),
                     ),
@@ -647,7 +648,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.grey.withOpacity(0.1),
+                      color: Colors.grey.withValues(alpha: (0.1 * 255).round()),
                       blurRadius: 8,
                       offset: const Offset(0, 4),
                     ),
@@ -709,7 +710,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                 borderRadius: BorderRadius.circular(12),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.grey.withOpacity(0.1),
+                    color: Colors.grey.withValues(alpha: (0.1 * 255).round()),
                     blurRadius: 8,
                     offset: const Offset(0, 4),
                   ),

--- a/lib/features/contacts/presentation/screens/contact_files_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_files_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -669,7 +670,7 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                         decoration: BoxDecoration(
                           color: _getFileIconColor(
                             file.name.split('.').last,
-                          ).withOpacity(0.2),
+                          ).withValues(alpha: (0.2 * 255).round()),
                           borderRadius: BorderRadius.circular(8),
                         ),
                         child: Icon(

--- a/lib/features/contacts/presentation/screens/contact_group_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_group_screen.dart
@@ -221,7 +221,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0.5,

--- a/lib/features/contacts/presentation/screens/contact_notes_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_notes_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:intl/intl.dart';
@@ -142,7 +143,7 @@ class _ContactNotesScreenState extends State<ContactNotesScreen> {
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
+                    color: Colors.black.withValues(alpha: (0.1 * 255).round()),
                     blurRadius: 20,
                     spreadRadius: 5,
                   ),

--- a/lib/features/contacts/presentation/screens/contacts_screen.dart
+++ b/lib/features/contacts/presentation/screens/contacts_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:contactsafe/features/contacts/presentation/provider/contacts_provider.dart';
 import 'package:contactsafe/features/contacts/presentation/widgets/contact_list_widget.dart';
 import 'package:contactsafe/features/settings/controller/settings_controller.dart';
@@ -169,9 +170,9 @@ class _ContactsScreenState extends State<ContactsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.background,
+        backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
         title: Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -215,7 +216,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
               icon: Container(
                 padding: const EdgeInsets.all(6),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                  color: Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(Icons.add, color: Colors.blue, size: 24),
@@ -252,7 +253,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
                   borderRadius: BorderRadius.circular(16),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.05),
+                      color: Colors.black.withValues(alpha: (0.05 * 255).round()),
                       blurRadius: 16,
                       offset: const Offset(0, 4),
                     ),
@@ -284,7 +285,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
         decoration: BoxDecoration(
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: (0.1 * 255).round()),
               blurRadius: 16,
               offset: const Offset(0, -4),
             ),

--- a/lib/features/contacts/presentation/screens/edit_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/edit_contact_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 import 'package:image_picker/image_picker.dart';
@@ -310,7 +311,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
             labelText,
             style: TextStyle(
               fontSize: 12,
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
             ),
           ),
           const SizedBox(height: 4),
@@ -416,7 +417,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
             'Phone (${_getPhoneLabelString(_phoneLabels[0])})',
             style: TextStyle(
               fontSize: 12,
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
             ),
           ),
           ListView.builder(
@@ -508,14 +509,14 @@ class _EditContactScreenState extends State<EditContactScreen> {
               },
               icon: Icon(
                 Icons.add_circle_outline,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ),
               label: Text(
                 'Add phone',
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -618,7 +619,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
                       fontSize: 12,
                       color: Theme.of(
                         context,
-                      ).colorScheme.onSurface.withOpacity(0.6),
+                      ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                     ),
                   ),
                   const SizedBox(height: 4),
@@ -708,14 +709,14 @@ class _EditContactScreenState extends State<EditContactScreen> {
               onPressed: onAdd,
               icon: Icon(
                 Icons.add_circle_outline,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ),
               label: Text(
                 'Add $label',
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -729,7 +730,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
@@ -881,7 +882,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
                         Icons.clear,
                         color: Theme.of(
                           context,
-                        ).colorScheme.onSurface.withOpacity(0.6),
+                        ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                       ),
                       onPressed: () {
                         setState(() {
@@ -938,14 +939,14 @@ class _EditContactScreenState extends State<EditContactScreen> {
                     backgroundColor: Theme.of(context).colorScheme.primary,
                     foregroundColor: Theme.of(
                       context,
-                    ).colorScheme.onSurface.withOpacity(0.6),
+                    ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                     elevation: 0,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10.0),
                       side: BorderSide(
                         color: Theme.of(
                           context,
-                        ).colorScheme.onSurface.withOpacity(0.6),
+                        ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                         width: 1,
                       ),
                     ),

--- a/lib/features/contacts/presentation/widgets/contact_list_widget.dart
+++ b/lib/features/contacts/presentation/widgets/contact_list_widget.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
 
@@ -35,7 +36,7 @@ class ContactListWidget extends StatelessWidget {
                     size: 48,
                     color: Theme.of(
                       context,
-                    ).colorScheme.onSurface.withOpacity(0.4),
+                    ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                   ),
                   const SizedBox(height: 16),
                   Text(
@@ -44,7 +45,7 @@ class ContactListWidget extends StatelessWidget {
                       fontSize: 18,
                       color: Theme.of(
                         context,
-                      ).colorScheme.onSurface.withOpacity(0.6),
+                      ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                     ),
                   ),
                 ],
@@ -93,7 +94,7 @@ class ContactListWidget extends StatelessWidget {
                             indent: 72,
                             color: Theme.of(
                               context,
-                            ).colorScheme.outline.withOpacity(0.2),
+                            ).colorScheme.outline.withValues(alpha: (0.2 * 255).round()),
                           ),
                     ),
                   ],
@@ -112,7 +113,7 @@ class ContactListWidget extends StatelessWidget {
           child: Center(
             child: Container(
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface.withOpacity(0.7),
+                color: Theme.of(context).colorScheme.surface.withValues(alpha: (0.7 * 255).round()),
                 borderRadius: BorderRadius.circular(12),
               ),
               padding: const EdgeInsets.symmetric(vertical: 8),
@@ -176,8 +177,8 @@ class ContactListItem extends StatelessWidget {
       color: Theme.of(context).colorScheme.surface,
       child: InkWell(
         onTap: onTap,
-        splashColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
-        highlightColor: Theme.of(context).colorScheme.primary.withOpacity(0.05),
+        splashColor: Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
+        highlightColor: Theme.of(context).colorScheme.primary.withValues(alpha: (0.05 * 255).round()),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
           child: Row(
@@ -205,7 +206,7 @@ class ContactListItem extends StatelessWidget {
                   size: 20,
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.4),
+                  ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                 ),
               ),
             ],
@@ -221,7 +222,7 @@ class ContactListItem extends StatelessWidget {
       height: 40,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+        color: Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
       ),
       child: Center(
         child:

--- a/lib/features/events/presentation/screens/events_detail_screen.dart
+++ b/lib/features/events/presentation/screens/events_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 // lib/features/events/presentation/screens/events_detail_screen.dart
 
 import 'package:flutter/material.dart';
@@ -253,7 +254,7 @@ class _EventsDetailScreenState extends State<EventsDetailScreen> {
                   style: TextStyle(
                     color: Theme.of(
                       context,
-                    ).colorScheme.onBackground.withOpacity(0.7),
+                    ).colorScheme.onBackground.withValues(alpha: (0.7 * 255).round()),
                   ),
                 )
                 : ListView.builder(
@@ -313,7 +314,7 @@ class _EventsDetailScreenState extends State<EventsDetailScreen> {
                 style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
-                  color: Theme.of(context).colorScheme.onBackground.withOpacity(0.8),
+                  color: Theme.of(context).colorScheme.onBackground.withValues(alpha: (0.8 * 255).round()),
                 ),
               ),
               Text(

--- a/lib/features/events/presentation/screens/events_screen.dart
+++ b/lib/features/events/presentation/screens/events_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:contactsafe/shared/widgets/customsearchbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
@@ -256,7 +257,7 @@ class _EventsScreenState extends State<EventsScreen> {
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
+                    color: Colors.black.withValues(alpha: (0.1 * 255).round()),
                     blurRadius: 20,
                     spreadRadius: 5,
                   ),
@@ -526,7 +527,7 @@ class _EventsScreenState extends State<EventsScreen> {
           ),
         ],
       ),
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -659,7 +660,7 @@ class EventCard extends StatelessWidget {
                   style: TextStyle(
                     color: Theme.of(
                       context,
-                    ).colorScheme.onSurface.withOpacity(0.7),
+                    ).colorScheme.onSurface.withValues(alpha: (0.7 * 255).round()),
                   ),
                 ),
               const SizedBox(height: 8),
@@ -668,7 +669,7 @@ class EventCard extends StatelessWidget {
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 ),
               ),
               const SizedBox(height: 8),
@@ -687,7 +688,7 @@ class EventCard extends StatelessWidget {
                       fontStyle: FontStyle.italic,
                       color: Theme.of(
                         context,
-                      ).colorScheme.onSurface.withOpacity(0.7),
+                      ).colorScheme.onSurface.withValues(alpha: (0.7 * 255).round()),
                     ),
                   ),
                 ),

--- a/lib/features/photos/presentation/screens/photos_screen.dart
+++ b/lib/features/photos/presentation/screens/photos_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -287,7 +288,7 @@ class _PhotosScreenState extends State<PhotosScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         title: Row(
@@ -367,7 +368,7 @@ class _PhotosScreenState extends State<PhotosScreen> {
                               size: 64,
                               color: Theme.of(
                                 context,
-                              ).colorScheme.onSurface.withOpacity(0.4),
+                              ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                             ),
                             const SizedBox(height: 16),
                             Text(
@@ -376,7 +377,7 @@ class _PhotosScreenState extends State<PhotosScreen> {
                                 fontSize: 18,
                                 color: Theme.of(
                                   context,
-                                ).colorScheme.onSurface.withOpacity(0.6),
+                                ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                               ),
                             ),
                             const SizedBox(height: 8),
@@ -387,7 +388,7 @@ class _PhotosScreenState extends State<PhotosScreen> {
                                 fontSize: 14,
                                 color: Theme.of(
                                   context,
-                                ).colorScheme.onSurface.withOpacity(0.6),
+                                ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                               ),
                             ),
                           ],

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:contactsafe/features/settings/controller/settings_controller.dart';
 import 'package:contactsafe/features/settings/presentation/screens/pin_dialog.dart';
 import 'package:contactsafe/features/settings/presentation/screens/select_tab_bar_order_screen.dart';
@@ -368,7 +369,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.surface,
         title: Row(
@@ -389,24 +390,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
       body: SettingsList(
         lightTheme: SettingsThemeData(
-          settingsListBackground: Theme.of(context).colorScheme.background,
+          settingsListBackground: Theme.of(context).colorScheme.surface,
           settingsSectionBackground: Theme.of(context).colorScheme.surface,
           titleTextColor: Theme.of(context).colorScheme.primary,
           settingsTileTextColor: Theme.of(context).colorScheme.onSurface,
           tileDescriptionTextColor: Theme.of(
             context,
-          ).colorScheme.onSurface.withOpacity(0.6),
-          dividerColor: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
+          dividerColor: Theme.of(context).colorScheme.outline.withValues(alpha: (0.2 * 255).round()),
         ),
         darkTheme: SettingsThemeData(
-          settingsListBackground: Theme.of(context).colorScheme.background,
+          settingsListBackground: Theme.of(context).colorScheme.surface,
           settingsSectionBackground: Theme.of(context).colorScheme.surface,
           titleTextColor: Theme.of(context).colorScheme.primary,
           settingsTileTextColor: Theme.of(context).colorScheme.onSurface,
           tileDescriptionTextColor: Theme.of(
             context,
-          ).colorScheme.onSurface.withOpacity(0.6),
-          dividerColor: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
+          dividerColor: Theme.of(context).colorScheme.outline.withValues(alpha: (0.2 * 255).round()),
         ),
         sections: [
           CustomSettingsSection(
@@ -436,7 +437,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text(
               'Privacy',
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -447,7 +448,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   Icons.chevron_right,
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.4),
+                  ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                 ),
                 onPressed: (context) async => await openAppSettings(),
               ),
@@ -456,7 +457,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 trailing: Text(
                   _languageLabel(_currentLanguage),
                   style: TextStyle(
-                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                   ),
                 ),
                 onPressed: (context) => _showLanguageDialog(),
@@ -467,7 +468,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text(
               'About',
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -479,7 +480,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   style: TextStyle(
                     color: Theme.of(
                       context,
-                    ).colorScheme.onSurface.withOpacity(0.6),
+                    ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                     fontSize: 15.0,
                   ),
                 ),
@@ -491,7 +492,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   Icons.open_in_new,
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.4),
+                  ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                 ),
                 onPressed:
                     (context) => _launchUrl(
@@ -504,7 +505,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   Icons.open_in_new,
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.4),
+                  ).colorScheme.onSurface.withValues(alpha: (0.4 * 255).round()),
                 ),
                 onPressed:
                     (context) => _launchUrl(
@@ -517,7 +518,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text(
               'General',
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -545,7 +546,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text(
               'Data Management',
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -623,7 +624,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               'App Customization & Reset',
               style: TextStyle(
                 fontWeight: FontWeight.w500,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ),
             ),
             tiles: [
@@ -691,7 +692,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               'Security',
               style: TextStyle(
                 fontWeight: FontWeight.w500,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
               ),
             ),
             tiles: [
@@ -785,7 +786,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   fontSize: 12.0,
                   color: Theme.of(
                     context,
-                  ).colorScheme.onSurface.withOpacity(0.6),
+                  ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
                 ),
               ),
             ),

--- a/lib/shared/widgets/customsearchbar.dart
+++ b/lib/shared/widgets/customsearchbar.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 
 class CustomSearchBar extends StatelessWidget {
@@ -20,7 +21,7 @@ class CustomSearchBar extends StatelessWidget {
         borderRadius: BorderRadius.circular(12.0),
         boxShadow: [
           BoxShadow(
-            color: Colors.grey.withOpacity(0.1),
+            color: Colors.grey.withValues(alpha: (0.1 * 255).round()),
             spreadRadius: 2,
             blurRadius: 8,
             offset: const Offset(0, 4),
@@ -37,13 +38,13 @@ class CustomSearchBar extends StatelessWidget {
         decoration: InputDecoration(
           hintText: hintText,
           hintStyle: TextStyle(
-            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.5 * 255).round()),
             fontWeight: FontWeight.normal,
             fontSize: 16.0,
           ),
           prefixIcon: Icon(
             Icons.search,
-            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: (0.5 * 255).round()),
             size: 24.0,
           ),
           suffixIcon:
@@ -53,7 +54,7 @@ class CustomSearchBar extends StatelessWidget {
                       Icons.clear,
                       color: Theme.of(
                         context,
-                      ).colorScheme.onSurface.withOpacity(0.5),
+                      ).colorScheme.onSurface.withValues(alpha: (0.5 * 255).round()),
                       size: 24.0,
                     ),
                     onPressed: () {

--- a/lib/shared/widgets/navigation_bar.dart
+++ b/lib/shared/widgets/navigation_bar.dart
@@ -1,3 +1,4 @@
+import 'package:contactsafe/utils/color_extensions.dart';
 import 'package:flutter/material.dart';
 
 class ContactSafeNavigationBar extends StatelessWidget {
@@ -19,7 +20,7 @@ class ContactSafeNavigationBar extends StatelessWidget {
       selectedItemColor: Colors.blue,
       unselectedItemColor: Theme.of(
         context,
-      ).colorScheme.onSurface.withOpacity(0.6),
+      ).colorScheme.onSurface.withValues(alpha: (0.6 * 255).round()),
       backgroundColor: Theme.of(context).colorScheme.surface,
       items: const [
         BottomNavigationBarItem(

--- a/lib/utils/color_extensions.dart
+++ b/lib/utils/color_extensions.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+
+extension ColorWithValues on Color {
+  /// Returns a copy of this color with the given channel values replaced.
+  /// Values should be in the range 0-255.
+  Color withValues({int? alpha, int? red, int? green, int? blue}) {
+    return Color.fromARGB(
+      alpha ?? this.alpha,
+      red ?? this.red,
+      green ?? this.green,
+      blue ?? this.blue,
+    );
+  }
+
+  /// Convenience method to set opacity as a double without precision loss.
+  Color withOpacityValue(double opacity) {
+    return withValues(alpha: (opacity * 255).round());
+  }
+}


### PR DESCRIPTION
## Summary
- add a `Color.withValues` extension
- use `withValues` instead of `withOpacity`
- switch ColorScheme `background` usage to `surface`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d663b5960832986ee094a08ae0cd6