### PR TITLE
Fix BuildContext usage after await

### DIFF
--- a/lib/features/events/presentation/screens/events_detail_screen.dart
+++ b/lib/features/events/presentation/screens/events_detail_screen.dart
@@ -78,6 +78,7 @@ class _EventsDetailScreenState extends State<EventsDetailScreen> {
     } catch (e) {
       debugPrint('Error geocoding event location: $e');
     } finally {
+      if (!mounted) return;
       setState(() {
         _isLoadingMap = false;
       });

--- a/lib/features/events/presentation/screens/events_screen.dart
+++ b/lib/features/events/presentation/screens/events_screen.dart
@@ -101,6 +101,7 @@ class _EventsScreenState extends State<EventsScreen> {
         withPhoto: true,
       );
       contacts.sort((a, b) => a.displayName.compareTo(b.displayName));
+      if (!mounted) return;
       setState(() {
         _allContacts = contacts;
       });
@@ -118,6 +119,7 @@ class _EventsScreenState extends State<EventsScreen> {
   Future<void> _fetchEvents() async {
     try {
       final events = await _eventRepository.loadEvents();
+      if (!mounted) return;
       setState(() {
         _events = events;
         _sortEvents();
@@ -460,6 +462,7 @@ class _EventsScreenState extends State<EventsScreen> {
 
                             try {
                           await _eventRepository.addEvent(newAppEvent);
+                          if (!mounted) return;
                           setState(() {
                                 _events.add(newAppEvent);
                                 _sortEvents();

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -60,7 +60,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _launchUrl(String urlString) async {
     final Uri url = Uri.parse(urlString);
-    if (!await launchUrl(url)) {
+    final success = await launchUrl(url);
+    if (!success && mounted) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Could not open $urlString')));
@@ -70,10 +71,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _importContacts() async {
     try {
       final count = await _controller.importContacts();
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Successfully imported $count contacts!')),
       );
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Error importing contacts: $e')));
@@ -83,10 +86,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _createBackup() async {
     try {
       final fileName = await _controller.createBackup();
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Backup created successfully at $fileName')),
       );
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Failed to create backup: $e')));
@@ -97,11 +102,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       final count = await _controller.restoreFromBackup();
       if (count > 0) {
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Restored $count contacts from backup!')),
         );
       }
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Failed to restore backup: $e')));
@@ -225,10 +232,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _deleteAllApplicationData() async {
     try {
       await _controller.deleteAllApplicationData();
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('All application data has been deleted.')),
       );
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Failed to delete all data: $e')));
@@ -360,7 +369,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ],
       ),
     );
-    if (selected != null) {
+    if (selected != null && mounted) {
       setState(() => _currentLanguage = selected);
       await _controller.saveLanguage(selected);
     }


### PR DESCRIPTION
## Summary
- avoid using `context` after an `await` in `SettingsScreen`
- ensure `mounted` is checked before calling `setState` in `EventsScreen`
- handle widget disposal in `EventsDetailScreen`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d6748d7b48329bb1e5060750d987d