### PR TITLE
Fix deprecated share API

### DIFF
--- a/lib/features/contacts/presentation/screens/contact_files_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_files_screen.dart
@@ -361,7 +361,8 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
       final tempDir = await getTemporaryDirectory();
       final tempFile = File('${tempDir.path}/${file.name}');
       await tempFile.writeAsBytes(data);
-      await Share.shareXFiles([XFile(tempFile.path)], text: file.name);
+      await SharePlus.instance
+          .share(files: [XFile(tempFile.path)], text: file.name);
     } catch (e) {
       _showSnackBar('Failed to share file: ${e.toString()}');
     }

--- a/lib/features/photos/presentation/screens/photos_screen.dart
+++ b/lib/features/photos/presentation/screens/photos_screen.dart
@@ -136,7 +136,7 @@ class _PhotosScreenState extends State<PhotosScreen> {
   Future<void> _shareSelectedPhotos() async {
     final files = _selectedIndices.map((i) => XFile(_photos[i].path)).toList();
     if (files.isNotEmpty) {
-      await Share.shareXFiles(files);
+      await SharePlus.instance.share(files: files);
     }
   }
 


### PR DESCRIPTION
## Summary
- use `SharePlus.instance.share` instead of deprecated `Share.shareXFiles`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d69c8909c832993cc42167eb373a9