### PR TITLE
Fix theme colors and shadows

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
 import 'colors.dart';
 
-final ThemeData lightTheme = ThemeData(
+final ColorScheme _lightColorScheme = ColorScheme.fromSeed(
+  seedColor: kIOSPrimaryBlue,
   brightness: Brightness.light,
+);
+
+final ColorScheme _darkColorScheme = ColorScheme.fromSeed(
+  seedColor: kIOSPrimaryBlue,
+  brightness: Brightness.dark,
+);
+
+final ThemeData lightTheme = ThemeData(
+  useMaterial3: true,
+  colorScheme: _lightColorScheme,
   scaffoldBackgroundColor: kIOSBackground,
   primaryColor: kIOSPrimaryBlue,
   appBarTheme: AppBarTheme(
@@ -20,9 +31,9 @@ final ThemeData lightTheme = ThemeData(
   iconTheme: IconThemeData(color: kIOSPrimaryBlue),
   bottomNavigationBarTheme: BottomNavigationBarThemeData(
     backgroundColor: kIOSWhite,
-    selectedItemColor: kIOSPrimaryBlue,
+    selectedItemColor: _lightColorScheme.primary,
     unselectedItemColor: kIOSSecondaryText,
-    selectedIconTheme: IconThemeData(color: kIOSPrimaryBlue),
+    selectedIconTheme: IconThemeData(color: _lightColorScheme.primary),
     unselectedIconTheme: IconThemeData(color: kIOSSecondaryText),
     type: BottomNavigationBarType.fixed,
     showUnselectedLabels: true,
@@ -43,10 +54,12 @@ final ThemeData lightTheme = ThemeData(
               : kIOSDivider,
     ),
   ),
+  shadowColor: Colors.black.withOpacity(0.2),
 );
 
 final ThemeData darkTheme = ThemeData(
-  brightness: Brightness.dark,
+  useMaterial3: true,
+  colorScheme: _darkColorScheme,
   scaffoldBackgroundColor: kIOSDarkBackground,
   primaryColor: kIOSPrimaryBlue,
   appBarTheme: AppBarTheme(
@@ -64,9 +77,9 @@ final ThemeData darkTheme = ThemeData(
   iconTheme: IconThemeData(color: kIOSPrimaryBlue),
   bottomNavigationBarTheme: BottomNavigationBarThemeData(
     backgroundColor: kIOSDarkCard,
-    selectedItemColor: kIOSPrimaryBlue,
+    selectedItemColor: _darkColorScheme.primary,
     unselectedItemColor: kIOSDarkSecondaryText,
-    selectedIconTheme: IconThemeData(color: kIOSPrimaryBlue),
+    selectedIconTheme: IconThemeData(color: _darkColorScheme.primary),
     unselectedIconTheme: IconThemeData(color: kIOSDarkSecondaryText),
     type: BottomNavigationBarType.fixed,
     showUnselectedLabels: true,
@@ -87,4 +100,5 @@ final ThemeData darkTheme = ThemeData(
               : kIOSDarkDivider,
     ),
   ),
+  shadowColor: Colors.black.withOpacity(0.2),
 );

--- a/lib/features/contacts/presentation/screens/contact_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_detail_screen.dart
@@ -322,7 +322,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
         '$count',
         style: TextStyle(
           fontSize: 14,
-          color: Colors.blue,
+          color: Theme.of(context).colorScheme.primary,
           fontWeight: FontWeight.w600,
         ),
       ),
@@ -336,7 +336,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-        border: Border.all(color: Colors.blue, width: 2),
+        border: Border.all(color: Theme.of(context).colorScheme.primary, width: 2),
       ),
       child:
           contact.photo != null && contact.photo!.isNotEmpty
@@ -356,7 +356,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                   style: TextStyle(
                     fontSize: 48,
                     fontWeight: FontWeight.bold,
-                    color: Colors.blue,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
               ),
@@ -387,7 +387,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
             ),
             child: Column(
               children: [
-                Icon(icon, size: 28, color: Colors.blue),
+                Icon(icon, size: 28, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(height: 8),
                 Text(
                   label,
@@ -415,7 +415,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
             title,
             style: TextStyle(
               fontSize: 13,
-              color: Colors.blue,
+              color: Theme.of(context).colorScheme.primary,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -456,7 +456,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                 children: [
                   _buildCountBadge(count),
                   const SizedBox(width: 4),
-                  Icon(Icons.chevron_right, color: Colors.blue),
+                  Icon(Icons.chevron_right, color: Theme.of(context).colorScheme.primary),
                 ],
               ),
             ],
@@ -486,7 +486,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
         elevation: 0.5,
         centerTitle: true,
         leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: Colors.blue),
+          icon: Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.primary),
           onPressed: () => Navigator.pop(context),
         ),
         title: Row(
@@ -506,7 +506,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
         ),
         actions: [
           IconButton(
-            icon: Icon(Icons.edit, color: Colors.blue),
+            icon: Icon(Icons.edit, color: Theme.of(context).colorScheme.primary),
             onPressed: () {
               Navigator.push(
                 context,
@@ -522,7 +522,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
           IconButton(
             icon: Icon(
               _isFavorite ? Icons.star : Icons.star_border,
-              color: Colors.blue,
+              color: Theme.of(context).colorScheme.primary,
             ),
             onPressed: () {
               _toggleFavorite();
@@ -671,7 +671,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.blue,
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
                     ),

--- a/lib/features/contacts/presentation/screens/contact_group_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_group_screen.dart
@@ -146,7 +146,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
               child: Text(
                 'OK', // Changed text from "Add Group" to "OK" for general add
                 style: TextStyle(
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -166,7 +166,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
               child: Text(
                 'Ok & add contacts',
                 style: TextStyle(
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                   fontWeight: FontWeight.bold,
                 ),
               ),
@@ -243,7 +243,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
             child: Text(
               'Done',
               style: TextStyle(
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
                 fontSize: 16.0,
                 fontWeight: FontWeight.bold,
               ),
@@ -253,7 +253,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
         leadingWidth: 70.0,
         actions: [
           IconButton(
-            icon: Icon(Icons.add, color: Colors.blue, size: 28),
+            icon: Icon(Icons.add, color: Theme.of(context).colorScheme.primary, size: 28),
             onPressed: () => _addNewGroup(context),
             splashRadius: 24,
           ),
@@ -340,7 +340,7 @@ class _ContactGroupsScreenState extends State<ContactGroupsScreen> {
                               _toggleGroupSelection(group);
                             }
                           },
-                          activeColor: Colors.blue,
+                          activeColor: Theme.of(context).colorScheme.primary,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(4.0),
                           ),

--- a/lib/features/events/presentation/screens/events_screen.dart
+++ b/lib/features/events/presentation/screens/events_screen.dart
@@ -205,7 +205,7 @@ class _EventsScreenState extends State<EventsScreen> {
                   title: Text(_getSortOptionName(option)),
                   trailing:
                       _sortOption == option
-                          ? const Icon(Icons.check, color: Colors.blue)
+                          ? Icon(Icons.check, color: Theme.of(context).colorScheme.primary)
                           : null,
                   onTap: () {
                     setState(() {
@@ -277,12 +277,12 @@ class _EventsScreenState extends State<EventsScreen> {
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
+                        Text(
                           'New Event',
                           style: TextStyle(
                             fontSize: 20,
                             fontWeight: FontWeight.bold,
-                            color: Colors.blue,
+                            color: Theme.of(context).colorScheme.primary,
                           ),
                         ),
                         const SizedBox(height: 16),
@@ -445,8 +445,8 @@ class _EventsScreenState extends State<EventsScreen> {
                           icon: const Icon(Icons.map),
                           label: const Text('Choose Location on Map'),
                           style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.blue,
-                            foregroundColor: Colors.white,
+                            backgroundColor: Theme.of(context).colorScheme.primary,
+                            foregroundColor: Theme.of(context).colorScheme.onPrimary,
                             padding: const EdgeInsets.symmetric(vertical: 15),
                           ),
                         ),
@@ -571,11 +571,11 @@ class _EventsScreenState extends State<EventsScreen> {
         actions: [
           IconButton(
             onPressed: _showSortDialog,
-            icon: Icon(Icons.swap_vert, color: Colors.blue, size: 30),
+            icon: Icon(Icons.swap_vert, color: Theme.of(context).colorScheme.primary, size: 30),
           ),
           IconButton(
             onPressed: _addNewEvent,
-            icon: Icon(Icons.add, color: Colors.blue, size: 30),
+            icon: Icon(Icons.add, color: Theme.of(context).colorScheme.primary, size: 30),
           ),
         ],
       ),

--- a/lib/features/events/presentation/widgets/location_picker_screen.dart
+++ b/lib/features/events/presentation/widgets/location_picker_screen.dart
@@ -191,8 +191,8 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
                             });
                           },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.blue, // Theme color
-                    foregroundColor: Colors.white,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
                     padding: const EdgeInsets.symmetric(vertical: 15),
                   ),
                   child: const Text(

--- a/lib/features/settings/presentation/widgets/onboarding_screen.dart
+++ b/lib/features/settings/presentation/widgets/onboarding_screen.dart
@@ -32,7 +32,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         backgroundColor: Colors.transparent, // Make app bar transparent
         elevation: 0, // Remove shadow
         leading: IconButton(
-          icon: const Icon(Icons.close, color: Colors.black), // Close button
+          icon: Icon(Icons.close, color: Theme.of(context).colorScheme.onSurface),
           onPressed: () {
             Navigator.of(
               context,
@@ -109,8 +109,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   decoration: BoxDecoration(
                     color:
                         _currentPage == index
-                            ? Theme.of(context).primaryColor
-                            : Colors.grey,
+                            ? Theme.of(context).colorScheme.primary
+                            : Theme.of(context).colorScheme.onSurfaceVariant,
                     borderRadius: BorderRadius.circular(5.0),
                   ),
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_contacts/contact.dart';
 import 'package:contactsafe/app.dart';
 import 'package:contactsafe/firebase_options.dart';
+import 'package:contactsafe/core/theme/theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -33,8 +34,8 @@ void main() async {
   runApp(
     MaterialApp(
       title: 'ContactSafe',
-      theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
-      darkTheme: ThemeData.dark(useMaterial3: true),
+      theme: lightTheme,
+      darkTheme: darkTheme,
       themeMode: ThemeMode.system,
       debugShowCheckedModeBanner: false,
       initialRoute: '/',

--- a/lib/shared/widgets/navigation_bar.dart
+++ b/lib/shared/widgets/navigation_bar.dart
@@ -16,7 +16,7 @@ class ContactSafeNavigationBar extends StatelessWidget {
       currentIndex: currentIndex,
       onTap: onTap,
       type: BottomNavigationBarType.fixed,
-      selectedItemColor: Colors.blue,
+      selectedItemColor: Theme.of(context).colorScheme.primary,
       unselectedItemColor: Theme.of(context).colorScheme.onSurfaceVariant,
       backgroundColor: Theme.of(context).colorScheme.surface,
       items: const [


### PR DESCRIPTION
## Summary
- apply new color scheme-based theming for light and dark modes
- wire custom themes into the main app
- update navigation bar and widgets to use themed colors
- clean up hard-coded blues in contacts and events screens
- ensure onboarding screen and group screens respect theme colors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e86cc843483298b8a9054526c5c73