### PR TITLE
Add anonymous auth and user-scoped data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /user_files/{userId}/contacts/{contactId}/files/{fileId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /user_notes/{userId}/contacts/{contactId}/notes/{noteId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /user_contacts/{userId}/contacts/{contactId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -8,6 +8,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:intl_phone_field/intl_phone_field.dart';
 import 'package:flutter/services.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class AddContactScreen extends StatefulWidget {
   const AddContactScreen({super.key});
@@ -176,6 +177,8 @@ class _AddContactScreenState extends State<AddContactScreen> {
 
       // 2. Save to Cloud Firestore
       await _firestore
+          .collection('user_contacts')
+          .doc(FirebaseAuth.instance.currentUser!.uid)
           .collection('contacts')
           .add(firestoreContactData); // <<< SAVE TO FIRESTORE
       if (mounted) {

--- a/lib/features/contacts/presentation/screens/contact_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:contactsafe/features/contacts/presentation/screens/edit_contact_screen.dart';
@@ -44,13 +45,17 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
     try {
       final filesSnapshot =
           await FirebaseFirestore.instance
-              .collection('contact_files_metadata')
+              .collection('user_files')
+              .doc(FirebaseAuth.instance.currentUser!.uid)
+              .collection('contacts')
               .doc(widget.contact.id)
               .collection('files')
               .get();
       final notesSnapshot =
           await FirebaseFirestore.instance
-              .collection('contact_notes')
+              .collection('user_notes')
+              .doc(FirebaseAuth.instance.currentUser!.uid)
+              .collection('contacts')
               .doc(widget.contact.id)
               .collection('notes')
               .get();

--- a/lib/features/photos/presentation/screens/photos_screen.dart
+++ b/lib/features/photos/presentation/screens/photos_screen.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 import 'package:contactsafe/shared/widgets/navigation_bar.dart';
@@ -29,8 +30,11 @@ class _PhotosScreenState extends State<PhotosScreen> {
     });
 
     try {
-      final snapshot =
-          await FirebaseFirestore.instance.collectionGroup('files').get();
+      final uid = FirebaseAuth.instance.currentUser!.uid;
+      final snapshot = await FirebaseFirestore.instance
+          .collectionGroup('files')
+          .where('uid', isEqualTo: uid)
+          .get();
       const imageExts = ['.jpg', '.jpeg', '.png', '.gif'];
 
       final urls = snapshot.docs.map((doc) {

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -7,6 +7,7 @@ import 'package:contactsafe/features/events/data/models/event_model.dart';
 import 'package:contactsafe/features/events/presentation/screens/events_detail_screen.dart';
 import 'package:contactsafe/shared/widgets/customsearchbar.dart';
 import 'package:contactsafe/shared/widgets/navigation_bar.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class _FileResult {
   final String id;
@@ -75,9 +76,12 @@ class _SearchScreenState extends State<SearchScreen> {
         });
       }
 
-      // Fetch files across all contacts
-      final fileSnapshots =
-          await FirebaseFirestore.instance.collectionGroup('files').get();
+      // Fetch files for this user only
+      final uid = FirebaseAuth.instance.currentUser!.uid;
+      final fileSnapshots = await FirebaseFirestore.instance
+          .collectionGroup('files')
+          .where('uid', isEqualTo: uid)
+          .get();
       final files =
           fileSnapshots.docs.map((doc) {
             final data = doc.data();
@@ -94,9 +98,11 @@ class _SearchScreenState extends State<SearchScreen> {
             );
           }).toList();
 
-      // Fetch notes across all contacts
-      final noteSnapshots =
-          await FirebaseFirestore.instance.collectionGroup('notes').get();
+      // Fetch notes for this user only
+      final noteSnapshots = await FirebaseFirestore.instance
+          .collectionGroup('notes')
+          .where('uid', isEqualTo: uid)
+          .get();
       final notes =
           noteSnapshots.docs.map((doc) {
             final data = doc.data();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:contactsafe/features/settings/presentation/screens/pin_verificat
 import 'package:contactsafe/features/settings/presentation/screens/settings_screen.dart';
 // import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/contact.dart';
 import 'package:contactsafe/app.dart';
@@ -21,6 +22,11 @@ import 'package:contactsafe/firebase_options.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  // Sign in anonymously if not already signed in
+  if (FirebaseAuth.instance.currentUser == null) {
+    await FirebaseAuth.instance.signInAnonymously();
+  }
 
   // await FirebaseAppCheck.instance.activate(
   //   webProvider: ReCaptchaV3Provider('recaptcha-v3-site-key'),

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,7 @@
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /user_files/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- sign in anonymously during app startup
- scope Firestore collections and Storage paths by the current user ID
- filter searches and photo loading by the authenticated user
- include basic security rules for Firestore and Storage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f338186b88329b1e29395b762a475