### PR TITLE
Add reusable centered AppBar widget

### DIFF
--- a/lib/shared/widgets/contactsafe_appbar.dart
+++ b/lib/shared/widgets/contactsafe_appbar.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+/// A reusable AppBar that keeps the [ContactSafe] title and logo perfectly
+/// centered regardless of the width of the leading widget or action buttons.
+class ContactSafeAppBar extends StatelessWidget implements PreferredSizeWidget {
+  /// Widget displayed at the start of the bar (usually a back button).
+  final Widget? leading;
+
+  /// Widgets displayed at the end of the bar.
+  final List<Widget>? actions;
+
+  /// A widget to display below the bar (e.g. a [TabBar]).
+  final PreferredSizeWidget? bottom;
+
+  /// Background color of the bar.
+  final Color? backgroundColor;
+
+  /// Elevation of the bar.
+  final double? elevation;
+
+  const ContactSafeAppBar({
+    super.key,
+    this.leading,
+    this.actions,
+    this.bottom,
+    this.backgroundColor,
+    this.elevation,
+  });
+
+  @override
+  Size get preferredSize => Size.fromHeight(
+        kToolbarHeight + (bottom?.preferredSize.height ?? 0),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: backgroundColor ?? theme.appBarTheme.backgroundColor,
+      elevation: elevation ?? theme.appBarTheme.elevation ?? 0,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SafeArea(
+            bottom: false,
+            child: SizedBox(
+              height: kToolbarHeight,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  if (leading != null)
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: leading,
+                    ),
+                  Center(
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'contactSafe',
+                          style: theme.appBarTheme.titleTextStyle,
+                        ),
+                        const SizedBox(width: 5),
+                        Image.asset('assets/contactsafe_logo.png', height: 26),
+                      ],
+                    ),
+                  ),
+                  if (actions != null && actions!.isNotEmpty)
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: actions!,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          if (bottom != null) bottom!,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/contactsafe_appbar_example.dart
+++ b/lib/shared/widgets/contactsafe_appbar_example.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'contactsafe_appbar.dart';
+
+/// Example screen demonstrating the [ContactSafeAppBar].
+class ContactSafeAppBarExample extends StatelessWidget {
+  const ContactSafeAppBarExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: ContactSafeAppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () {},
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.sort),
+            onPressed: () {},
+          ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {},
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Text('Example content'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ContactSafeAppBar` widget for a centered title and logo
- include `ContactSafeAppBarExample` demonstrating usage

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f464723608329ad344071c98f75a1