### PR TITLE
Use theme colors for file icons

### DIFF
--- a/lib/core/utils/backup
+++ b/lib/core/utils/backup
@@ -615,24 +615,24 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
   }
 
   Color _getFileIconColor(String? extension) {
+    final colorScheme = Theme.of(context).colorScheme;
     switch (extension?.toLowerCase()) {
       case 'pdf':
-        return Colors.red;
+        return colorScheme.error;
       case 'jpg':
       case 'jpeg':
-        return Colors.blue;
       case 'png':
-        return Colors.blue;
+        return colorScheme.primary;
       case 'doc':
       case 'docx':
-        return Colors.blue.shade800;
+        return colorScheme.primary;
       case 'xls':
       case 'xlsx':
-        return Colors.green;
+        return colorScheme.secondary;
       case 'txt':
-        return Colors.grey;
+        return colorScheme.outline;
       default:
-        return Colors.blue;
+        return colorScheme.primary;
     }
   }
 

--- a/lib/features/contacts/presentation/screens/contact_files_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_files_screen.dart
@@ -634,24 +634,24 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
   }
 
   Color _getFileIconColor(String? extension) {
+    final colorScheme = Theme.of(context).colorScheme;
     switch (extension?.toLowerCase()) {
       case 'pdf':
-        return Colors.red;
+        return colorScheme.error;
       case 'jpg':
       case 'jpeg':
-        return Colors.blue;
       case 'png':
-        return Colors.blue;
+        return colorScheme.primary;
       case 'doc':
       case 'docx':
-        return Colors.blue.shade800;
+        return colorScheme.primary;
       case 'xls':
       case 'xlsx':
-        return Colors.green;
+        return colorScheme.secondary;
       case 'txt':
-        return Colors.grey;
+        return colorScheme.outline;
       default:
-        return Colors.blue;
+        return colorScheme.primary;
     }
   }
 


### PR DESCRIPTION
## Summary
- use theme color scheme to style file icons instead of hardcoded `Colors.*`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c451de083298d1f12486d4d0220