### PR TITLE
Refactor blue colors to use theme

### DIFF
--- a/lib/core/utils/backup
+++ b/lib/core/utils/backup
@@ -548,7 +548,10 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                   title: Text(_getSortOptionName(option)),
                   trailing:
                       _sortOption == option
-                          ? const Icon(Icons.check, color: Colors.blue)
+                          ? Icon(
+                              Icons.check,
+                              color: Theme.of(context).colorScheme.primary,
+                            )
                           : null,
                   onTap: () {
                     setState(() {
@@ -661,12 +664,19 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
           ],
         ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Colors.blue),
+          icon: Icon(
+            Icons.arrow_back_ios,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () => Navigator.pop(context),
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.swap_vert, size: 30, color: Colors.blue),
+            icon: Icon(
+              Icons.swap_vert,
+              size: 30,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: _showSortDialog,
           ),
           if (_editMode)
@@ -688,14 +698,18 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
               child: const Text(
                 'Edit',
                 style: TextStyle(
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                   fontSize: 15,
                   fontWeight: FontWeight.bold,
                 ),
               ),
             ),
           IconButton(
-            icon: const Icon(Icons.add, size: 30, color: Colors.blue),
+            icon: Icon(
+              Icons.add,
+              size: 30,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: _isLoading ? null : _pickAndUploadFiles,
           ),
         ],
@@ -733,11 +747,18 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                   return Card(
                     elevation: 2,
                     margin: const EdgeInsets.only(bottom: 12),
-                    color: isSelected ? Colors.blue[50] : null,
+                    color: isSelected
+                        ? Theme.of(context)
+                            .colorScheme
+                            .primary
+                            .withOpacity(0.1)
+                        : null,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
                       side: BorderSide(
-                        color: isSelected ? Colors.blue : Colors.grey[300]!,
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.grey[300]!,
                         width: isSelected ? 1.5 : 1,
                       ),
                     ),
@@ -769,10 +790,12 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                       trailing:
                           _editMode
                               ? Checkbox(
-                                value: isSelected,
-                                onChanged: (value) => _toggleSelection(file.id),
-                                activeColor: Colors.blue,
-                              )
+                                  value: isSelected,
+                                  onChanged: (value) =>
+                                      _toggleSelection(file.id),
+                                  activeColor:
+                                      Theme.of(context).colorScheme.primary,
+                                )
                               : IconButton(
                                 icon: const Icon(
                                   Icons.more_vert,

--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -290,14 +290,18 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         fit: BoxFit.cover,
                       ),
                     )
-                    : Icon(Icons.person_outline, size: 48, color: Colors.blue),
+                    : Icon(
+                        Icons.person_outline,
+                        size: 48,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
           ),
         ),
         const SizedBox(height: 8),
         Text(
           _selectedPhoto != null ? 'Change picture' : 'Add picture',
           style: TextStyle(
-            color: Colors.blue,
+            color: Theme.of(context).colorScheme.primary,
             fontSize: 16,
             fontWeight: FontWeight.w500,
           ),
@@ -544,7 +548,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10.0),
-            side: BorderSide(color: Colors.blue, width: 1),
+            side: BorderSide(
+              color: Theme.of(context).colorScheme.primary,
+              width: 1,
+            ),
           ),
           padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 20.0),
           minimumSize: const Size(double.infinity, 50),
@@ -553,7 +560,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            Icon(icon, color: Colors.blue),
+            Icon(
+              icon,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             const SizedBox(width: 16),
             Text(
               text,
@@ -591,7 +601,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
         elevation: 0,
         centerTitle: true,
         leading: IconButton(
-          icon: Icon(Icons.close, color: Colors.blue),
+          icon: Icon(
+            Icons.close,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () {
             Navigator.pop(context);
           },
@@ -617,7 +630,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
             child: Text(
               'Save',
               style: TextStyle(
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
                 fontWeight: FontWeight.bold,
                 fontSize: 16,
               ),
@@ -976,20 +989,21 @@ class _AddContactScreenState extends State<AddContactScreen> {
               onPressed: onAdd,
               icon: Icon(
                 Icons.add_circle_outline,
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
                 size: 22,
               ),
               label: Text(
                 'Add $label',
                 style: TextStyle(
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                   fontWeight: FontWeight.w500,
                   fontSize: 15,
                 ),
               ),
               style: TextButton.styleFrom(
-                foregroundColor: Colors.blue,
-                backgroundColor: Colors.blue.withOpacity(0.08),
+                foregroundColor: Theme.of(context).colorScheme.primary,
+                backgroundColor:
+                    Theme.of(context).colorScheme.primary.withOpacity(0.08),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
                 ),

--- a/lib/features/contacts/presentation/screens/assign_contacts_to_group_screen.dart.dart
+++ b/lib/features/contacts/presentation/screens/assign_contacts_to_group_screen.dart.dart
@@ -144,14 +144,17 @@ class _AssignContactsToGroupScreenState
         centerTitle: true,
         title: Text(
           'Assign to "${widget.groupName}"',
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 18.0,
             fontWeight: FontWeight.bold,
-            color: Colors.blue,
+            color: Theme.of(context).colorScheme.primary,
           ),
         ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.blue),
+          icon: Icon(
+            Icons.arrow_back,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () {
             Navigator.pop(context);
           },
@@ -162,7 +165,7 @@ class _AssignContactsToGroupScreenState
             child: const Text(
               'Save',
               style: TextStyle(
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
                 fontWeight: FontWeight.bold,
                 fontSize: 16,
               ),
@@ -209,7 +212,8 @@ class _AssignContactsToGroupScreenState
                                 onChanged: (bool? value) {
                                   _toggleContactSelection(contact);
                                 },
-                                activeColor: Colors.blue,
+                                activeColor:
+                                    Theme.of(context).colorScheme.primary,
                                 shape: RoundedRectangleBorder(
                                   borderRadius: BorderRadius.circular(4.0),
                                 ),
@@ -245,7 +249,7 @@ class _AssignContactsToGroupScreenState
                                 contact.displayName,
                                 style: TextStyle(
                                   fontSize: 17.0,
-                                  color: Colors.blue,
+                                  color: Theme.of(context).colorScheme.primary,
                                   fontWeight:
                                       isSelected
                                           ? FontWeight.w600

--- a/lib/features/contacts/presentation/screens/contact_detail_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_detail_screen.dart
@@ -359,7 +359,10 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-        border: Border.all(color: Colors.blue, width: 2),
+        border: Border.all(
+          color: Theme.of(context).colorScheme.primary,
+          width: 2,
+        ),
       ),
       child:
           contact.photo != null && contact.photo!.isNotEmpty
@@ -379,7 +382,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                   style: TextStyle(
                     fontSize: 48,
                     fontWeight: FontWeight.bold,
-                    color: Colors.blue,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
               ),
@@ -415,7 +418,11 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
             ),
             child: Column(
               children: [
-                Icon(icon, size: 28, color: Colors.blue),
+                Icon(
+                  icon,
+                  size: 28,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
                 const SizedBox(height: 8),
                 Text(
                   label,
@@ -443,7 +450,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
             title,
             style: TextStyle(
               fontSize: 13,
-              color: Colors.blue,
+              color: Theme.of(context).colorScheme.primary,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -517,7 +524,10 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
         elevation: 0.5,
         centerTitle: true,
         leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: Colors.blue),
+          icon: Icon(
+            Icons.arrow_back,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () => Navigator.pop(context),
         ),
         title: Row(
@@ -537,7 +547,10 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
         ),
         actions: [
           IconButton(
-            icon: Icon(Icons.edit, color: Colors.blue),
+            icon: Icon(
+              Icons.edit,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: () {
               Navigator.push(
                 context,
@@ -553,7 +566,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
           IconButton(
             icon: Icon(
               _isFavorite ? Icons.star : Icons.star_border,
-              color: Colors.blue,
+              color: Theme.of(context).colorScheme.primary,
             ),
             onPressed: () {
               _toggleFavorite();
@@ -707,7 +720,7 @@ class _ContactDetailScreenState extends State<ContactDetailScreen> {
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w500,
-                          color: Colors.blue,
+                          color: Theme.of(context).colorScheme.primary,
                         ),
                       ),
                     ),

--- a/lib/features/contacts/presentation/screens/contact_files_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_files_screen.dart
@@ -567,7 +567,10 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                   title: Text(_getSortOptionName(option)),
                   trailing:
                       _sortOption == option
-                          ? const Icon(Icons.check, color: Colors.blue)
+                          ? Icon(
+                              Icons.check,
+                              color: Theme.of(context).colorScheme.primary,
+                            )
                           : null,
                   onTap: () {
                     setState(() {
@@ -680,12 +683,19 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
           ],
         ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Colors.blue),
+          icon: Icon(
+            Icons.arrow_back_ios,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () => Navigator.pop(context),
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.swap_vert, size: 30, color: Colors.blue),
+            icon: Icon(
+              Icons.swap_vert,
+              size: 30,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: _showSortDialog,
           ),
           if (_editMode)
@@ -707,14 +717,18 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
               child: const Text(
                 'Edit',
                 style: TextStyle(
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                   fontSize: 15,
                   fontWeight: FontWeight.bold,
                 ),
               ),
             ),
           IconButton(
-            icon: const Icon(Icons.add, size: 30, color: Colors.blue),
+            icon: Icon(
+              Icons.add,
+              size: 30,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: _isLoading ? null : _pickAndUploadFiles,
           ),
         ],
@@ -752,11 +766,18 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                   return Card(
                     elevation: 2,
                     margin: const EdgeInsets.only(bottom: 12),
-                    color: isSelected ? Colors.blue[50] : null,
+                    color: isSelected
+                        ? Theme.of(context)
+                            .colorScheme
+                            .primary
+                            .withOpacity(0.1)
+                        : null,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
                       side: BorderSide(
-                        color: isSelected ? Colors.blue : Colors.grey[300]!,
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.grey[300]!,
                         width: isSelected ? 1.5 : 1,
                       ),
                     ),
@@ -788,10 +809,12 @@ class _ContactFilesScreenState extends State<ContactFilesScreen> {
                       trailing:
                           _editMode
                               ? Checkbox(
-                                value: isSelected,
-                                onChanged: (value) => _toggleSelection(file.id),
-                                activeColor: Colors.blue,
-                              )
+                                  value: isSelected,
+                                  onChanged: (value) =>
+                                      _toggleSelection(file.id),
+                                  activeColor:
+                                      Theme.of(context).colorScheme.primary,
+                                )
                               : IconButton(
                                 icon: const Icon(
                                   Icons.more_vert,

--- a/lib/features/contacts/presentation/screens/contact_notes_screen.dart
+++ b/lib/features/contacts/presentation/screens/contact_notes_screen.dart
@@ -167,7 +167,7 @@ class _ContactNotesScreenState extends State<ContactNotesScreen> {
                     style: TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
-                      color: Colors.blue,
+                      color: Theme.of(context).colorScheme.primary,
                     ),
                   ),
                   const SizedBox(height: 16),
@@ -216,7 +216,8 @@ class _ContactNotesScreenState extends State<ContactNotesScreen> {
                           Navigator.pop(context);
                         },
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.blue,
+                          backgroundColor:
+                              Theme.of(context).colorScheme.primary,
                           padding: const EdgeInsets.symmetric(
                             horizontal: 24,
                             vertical: 12,
@@ -256,12 +257,19 @@ class _ContactNotesScreenState extends State<ContactNotesScreen> {
           ],
         ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Colors.blue),
+          icon: Icon(
+            Icons.arrow_back_ios,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () => Navigator.pop(context),
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.add, size: 30, color: Colors.blue),
+            icon: Icon(
+              Icons.add,
+              size: 30,
+              color: Theme.of(context).colorScheme.primary,
+            ),
             onPressed: () {
               _noteController.clear();
               _editingIndex = -1;

--- a/lib/features/contacts/presentation/screens/contacts_screen.dart
+++ b/lib/features/contacts/presentation/screens/contacts_screen.dart
@@ -211,10 +211,10 @@ class _ContactsScreenState extends State<ContactsScreen> {
             onPressed: _navigateToGroups,
             child: Text(
               context.loc.translate('group'),
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
               ),
             ),
           ),
@@ -231,7 +231,11 @@ class _ContactsScreenState extends State<ContactsScreen> {
                   ).colorScheme.primary.withOpacity(0.12),
                   shape: BoxShape.circle,
                 ),
-                child: Icon(Icons.add, color: Colors.blue, size: 24),
+                child: Icon(
+                  Icons.add,
+                  color: Theme.of(context).colorScheme.primary,
+                  size: 24,
+                ),
               ),
               onPressed: _addNewContact,
             ),

--- a/lib/features/contacts/presentation/screens/edit_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/edit_contact_screen.dart
@@ -285,7 +285,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
         Text(
           _selectedPhoto != null ? 'Change picture' : 'Add picture',
           style: TextStyle(
-            color: Colors.blue,
+            color: Theme.of(context).colorScheme.primary,
             fontSize: 16,
             fontWeight: FontWeight.w500,
           ),
@@ -728,7 +728,10 @@ class _EditContactScreenState extends State<EditContactScreen> {
         elevation: 0,
         centerTitle: true,
         leading: IconButton(
-          icon: const Icon(Icons.close, color: Colors.blue),
+          icon: Icon(
+            Icons.close,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           onPressed: () {
             Navigator.pop(context);
           },
@@ -754,7 +757,7 @@ class _EditContactScreenState extends State<EditContactScreen> {
             child: const Text(
               'Save',
               style: TextStyle(
-                color: Colors.blue,
+                color: Theme.of(context).colorScheme.primary,
                 fontWeight: FontWeight.bold,
                 fontSize: 16,
               ),

--- a/lib/features/contacts/presentation/widgets/contact_list_widget.dart
+++ b/lib/features/contacts/presentation/widgets/contact_list_widget.dart
@@ -70,7 +70,7 @@ class ContactListWidget extends StatelessWidget {
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 16,
-                          color: Colors.blue, // iOS blue
+                          color: Theme.of(context).colorScheme.primary, // iOS blue
                         ),
                       ),
                     ),
@@ -132,7 +132,7 @@ class ContactListWidget extends StatelessWidget {
                               style: TextStyle(
                                 fontWeight: FontWeight.bold,
                                 fontSize: 12,
-                                color: Colors.blue,
+                                color: Theme.of(context).colorScheme.primary,
                               ),
                             ),
                           ),
@@ -242,7 +242,7 @@ class ContactListItem extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.blue,
+                  color: Theme.of(context).colorScheme.primary,
                 ),
               )
               : null,

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -658,7 +658,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Import contacts',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) => _importContacts(),
@@ -668,7 +670,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Create backup',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) => _createBackup(),
@@ -678,7 +682,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Restore from backup',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) => _restoreFromBackup(),
@@ -688,7 +694,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Backup to Google Drive',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) => _backupToGoogleDrive(),
@@ -698,7 +706,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Restore from Google Drive',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) => _restoreFromGoogleDrive(),
@@ -708,7 +718,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Import backup from link',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) async {
@@ -735,7 +747,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Onboard Tour',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed:
@@ -751,7 +765,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: Center(
                   child: Text(
                     'Select TabBar order',
-                    style: TextStyle(color: Colors.blue),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
                   ),
                 ),
                 onPressed: (context) async {


### PR DESCRIPTION
## Summary
- replace various `Colors.blue` usages with `Theme.of(context).colorScheme.primary`
- update checkbox and highlight colors to derive from theme

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5d1db80c8329809aba95250102ce