### PR TITLE
Refactor some UI strings to use localization

### DIFF
--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -299,7 +299,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
         ),
         const SizedBox(height: 8),
         Text(
-          _selectedPhoto != null ? 'Change picture' : 'Add picture',
+          _selectedPhoto != null
+              ? context.loc.translate('changePicture')
+              : context.loc.translate('addPicture'),
           style: TextStyle(
             color: Theme.of(context).colorScheme.primary,
             fontSize: 16,
@@ -435,7 +437,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                       child: IntlPhoneField(
                         initialValue: _phoneNumbers[index],
                         decoration: InputDecoration(
-                          hintText: 'Enter phone number',
+                          hintText: context.loc.translate('enterPhoneNumber'),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(10.0),
                             borderSide: BorderSide(
@@ -514,7 +516,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                 color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
               ), // Grey icon
               label: Text(
-                'Add phone',
+                context.loc.translate('addPhone'),
                 style: TextStyle(
                   color: Theme.of(
                     context,
@@ -686,7 +688,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
             if (_emailControllers.isEmpty)
               _buildAddButton(
                 icon: Icons.email_outlined,
-                text: 'Add email',
+                text: context.loc.translate('addEmail'),
                 onPressed: () {
                   setState(() {
                     _emailControllers.add(TextEditingController());
@@ -769,7 +771,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
             if (_addressControllers.isEmpty)
               _buildAddButton(
                 icon: Icons.location_on_outlined,
-                text: 'Add address',
+                text: context.loc.translate('addAddress'),
                 onPressed: () {
                   setState(() {
                     _addressControllers.add(TextEditingController());
@@ -903,9 +905,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
                       maxLines: maxLines ?? 1,
                       decoration: InputDecoration(
                         hintText:
-                            label == "Email"
-                                ? "example@email.com"
-                                : "Enter address",
+                            label == 'Email'
+                                ? context.loc.translate('exampleEmail')
+                                : context.loc.translate('enterAddress'),
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(10.0),
                           borderSide: BorderSide(

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -309,7 +309,7 @@ class _SearchScreenState extends State<SearchScreen> {
         style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
       ),
       subtitle: Text(
-        'From: ${file.contactName}',
+        '${context.loc.translate('from')}: ${file.contactName}',
         style: TextStyle(
           color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
         ),
@@ -332,7 +332,7 @@ class _SearchScreenState extends State<SearchScreen> {
         style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
       ),
       subtitle: Text(
-        'From: ${note.contactName}',
+        '${context.loc.translate('from')}: ${note.contactName}',
         style: TextStyle(
           color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
         ),

--- a/lib/features/settings/presentation/widgets/onboarding_screen.dart
+++ b/lib/features/settings/presentation/widgets/onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/app_localizations.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
@@ -45,7 +46,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
               Navigator.of(context).pop(); // Skip/Done button
             },
             child: Text(
-              _currentPage == _onboardingImages.length - 1 ? 'Done' : 'Skip',
+              _currentPage == _onboardingImages.length - 1
+                  ? context.loc.translate('done')
+                  : context.loc.translate('skip'),
               style: TextStyle(color: Theme.of(context).primaryColor),
             ),
           ),

--- a/lib/l10n/app_de.json
+++ b/lib/l10n/app_de.json
@@ -114,6 +114,7 @@
   "couldNotOpenFile": "Datei konnte nicht geöffnet werden",
   "groups": "Gruppen",
   "done": "Fertig",
+  "skip": "Überspringen",
   "selectAllGroups": "Alle Gruppen auswählen",
   "newGroup": "Neue Gruppe",
   "enterNewGroup": "Geben Sie den Namen für die neue Gruppe ein:",
@@ -284,5 +285,6 @@
   "create_a_4_digit_pin": "Erstellen Sie eine 4-stellige PIN",
   "confirm_your_pin": "Bestätigen Sie Ihre PIN",
   "enter_your_pin": "PIN eingeben",
-  "incorrect_pin_try_again": "PIN ist falsch. Bitte erneut versuchen."
+  "incorrect_pin_try_again": "PIN ist falsch. Bitte erneut versuchen.",
+  "exampleContent": "Beispielinhalt"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -114,6 +114,7 @@
   "couldNotOpenFile": "Could not open file",
   "groups": "Groups",
   "done": "Done",
+  "skip": "Skip",
   "selectAllGroups": "Select all groups",
   "newGroup": "New Group",
   "enterNewGroup": "Enter the name for your new group:",
@@ -285,4 +286,5 @@
   "confirm_your_pin": "Confirm your PIN",
   "enter_your_pin": "Enter your PIN",
   "incorrect_pin_try_again": "Incorrect PIN. Please try again."
+  ,"exampleContent": "Example content"
 }

--- a/lib/l10n/app_mn.json
+++ b/lib/l10n/app_mn.json
@@ -114,6 +114,7 @@
   "couldNotOpenFile": "Файл нээж чадсангүй",
   "groups": "Бүлгүүд",
   "done": "Дууссан",
+  "skip": "Алгасах",
   "selectAllGroups": "Бүх бүлгийг сонгох",
   "newGroup": "Шинэ бүлэг",
   "enterNewGroup": "Шинэ бүлгийн нэрээ оруулна уу:",
@@ -284,5 +285,6 @@
   "create_a_4_digit_pin": "4 оронтой PIN үүсгэнэ үү",
   "confirm_your_pin": "PIN-ээ баталгаажуулна уу",
   "enter_your_pin": "PIN оруулна уу",
-  "incorrect_pin_try_again": "PIN буруу байна. Дахин оролдоно уу."
+  "incorrect_pin_try_again": "PIN буруу байна. Дахин оролдоно уу.",
+  "exampleContent": "Жишээ агуулга"
 }

--- a/lib/shared/widgets/contactsafe_appbar_example.dart
+++ b/lib/shared/widgets/contactsafe_appbar_example.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/app_localizations.dart';
 import 'contactsafe_appbar.dart';
 
 /// Example screen demonstrating the [ContactSafeAppBar].
@@ -24,8 +25,8 @@ class ContactSafeAppBarExample extends StatelessWidget {
           ),
         ],
       ),
-      body: const Center(
-        child: Text('Example content'),
+      body: Center(
+        child: Text(context.loc.translate('exampleContent')),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- localize Onboarding skip/done labels
- replace hardcoded 'From:' text in search results
- localize add contact buttons and hints
- demonstrate localization usage in app bar example
- add `skip` and `exampleContent` keys in l10n files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fb6b9d6ec83298bb013c1d106d862