### PR TITLE
Fix localization mapping and ARB syntax

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -286,5 +286,5 @@
   "confirm_your_pin": "Confirm your PIN",
   "enter_your_pin": "Enter your PIN",
   "incorrect_pin_try_again": "Incorrect PIN. Please try again."
-  ,"exampleContent": "Example content"
+  "exampleContent": "Example content"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -308,6 +308,38 @@ abstract class AppLocalizations {
         return 'Enter backup link';
       case 'import':
         return 'Import';
+      case 'addAddress':
+        return 'Add address';
+      case 'addEmail':
+        return 'Add email';
+      case 'addPhone':
+        return 'Add phone';
+      case 'addPicture':
+        return 'Add picture';
+      case 'changePicture':
+        return 'Change picture';
+      case 'delete_all_data':
+        return 'Delete All Data?';
+      case 'delete_all_data_confirm':
+        return 'Are you sure you want to delete ALL data from ContactSafe? This action cannot be undone.';
+      case 'done':
+        return 'Done';
+      case 'enterAddress':
+        return 'Enter address';
+      case 'enterPhoneNumber':
+        return 'Enter phone number';
+      case 'exampleContent':
+        return 'Example content';
+      case 'exampleEmail':
+        return 'example@email.com';
+      case 'from':
+        return 'From';
+      case 'newEvent':
+        return 'New Event';
+      case 'selectDate':
+        return 'Select Date';
+      case 'skip':
+        return 'Skip';
       default:
         return key;
     }


### PR DESCRIPTION
## Summary
- fix invalid trailing comma in `app_en.arb`
- add missing keys to `translate()` mapping

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe17a8c908329a2554c41414225e4