### PR TITLE
Fix localization lookups in settings screen

### DIFF
--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -127,8 +127,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            context.loc
-                .translate('failed_to_create_backup')
+            context.loc.failed_to_create_backup
                 .replaceFirst('{error}', e.toString()),
           ),
         ),
@@ -146,8 +145,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              context.loc
-                  .translate('restored_contacts_from_backup')
+              context.loc.restored_contacts_from_backup
                   .replaceFirst('{count}', '$count'),
             ),
           ),
@@ -160,8 +158,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            context.loc
-                .translate('failed_to_restore_backup')
+            context.loc.failed_to_restore_backup
                 .replaceFirst('{error}', e.toString()),
           ),
         ),
@@ -694,7 +691,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           SettingsSection(
             title: Text(
-              context.loc.translate('general'),
+              context.loc.general,
               style: TextStyle(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontWeight: FontWeight.w500,


### PR DESCRIPTION
## Summary
- use localization properties instead of calling them like functions
- fix placeholder replacements in settings screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff1614fb88329862a630b15056439