### PR TITLE
Fix missing context.loc extension

### DIFF
--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -9,6 +9,7 @@ import 'package:intl_phone_field/intl_phone_field.dart';
 import 'package:flutter/services.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 class AddContactScreen extends StatefulWidget {
   const AddContactScreen({super.key});

--- a/lib/features/contacts/presentation/screens/contacts_screen.dart
+++ b/lib/features/contacts/presentation/screens/contacts_screen.dart
@@ -8,6 +8,7 @@ import 'package:contactsafe/features/contacts/presentation/screens/assign_contac
 import 'package:contactsafe/shared/widgets/custom_search_bar.dart';
 import 'package:contactsafe/shared/widgets/navigation_bar.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 import 'add_contact_screen.dart';
 
 class ContactsScreen extends StatefulWidget {

--- a/lib/features/events/presentation/screens/events_screen.dart
+++ b/lib/features/events/presentation/screens/events_screen.dart
@@ -9,6 +9,7 @@ import 'package:contactsafe/features/events/data/models/event_model.dart';
 import 'package:contactsafe/features/events/presentation/screens/events_detail_screen.dart';
 import 'package:contactsafe/features/events/presentation/screens/location_picker_screen.dart';
 import 'package:contactsafe/shared/widgets/custom_search_bar.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 import '../../../../shared/widgets/navigation_bar.dart';
 

--- a/lib/features/photos/presentation/screens/photos_screen.dart
+++ b/lib/features/photos/presentation/screens/photos_screen.dart
@@ -1,4 +1,5 @@
 import 'package:contactsafe/l10n/app_localizations.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:contactsafe/l10n/app_localizations.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';

--- a/lib/features/settings/presentation/screens/select_tab_bar_order_screen.dart
+++ b/lib/features/settings/presentation/screens/select_tab_bar_order_screen.dart
@@ -1,5 +1,6 @@
 import 'package:contactsafe/shared/widgets/navigation_item.dart';
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 class SelectTabBarOrderScreen extends StatefulWidget {
   final List<NavigationItem> currentOrder;

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import 'package:contactsafe/features/settings/presentation/widgets/onboarding_sc
 import 'package:contactsafe/shared/widgets/navigation_bar.dart';
 import 'package:contactsafe/shared/widgets/navigation_item.dart';
 import 'package:contactsafe/l10n/app_localizations.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 import 'package:contactsafe/l10n/locale_provider.dart';
 
 class SettingsScreen extends StatefulWidget {

--- a/lib/features/settings/presentation/widgets/onboarding_screen.dart
+++ b/lib/features/settings/presentation/widgets/onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});

--- a/lib/l10n/context_loc.dart
+++ b/lib/l10n/context_loc.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+import 'app_localizations.dart';
+
+extension AppLocalizationsContext on BuildContext {
+  /// Shortcut to access the localized strings through the [BuildContext].
+  AppLocalizations get loc => AppLocalizations.of(this)!;
+}

--- a/lib/shared/widgets/contactsafe_appbar.dart
+++ b/lib/shared/widgets/contactsafe_appbar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 /// A reusable AppBar that keeps the [ContactSafe] title and logo perfectly
 /// centered regardless of the width of the leading widget or action buttons.

--- a/lib/shared/widgets/contactsafe_appbar_example.dart
+++ b/lib/shared/widgets/contactsafe_appbar_example.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 import 'contactsafe_appbar.dart';
 
 /// Example screen demonstrating the [ContactSafeAppBar].

--- a/lib/shared/widgets/navigation_bar.dart
+++ b/lib/shared/widgets/navigation_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:contactsafe/l10n/context_loc.dart';
 
 class ContactSafeNavigationBar extends StatelessWidget {
   final int currentIndex;


### PR DESCRIPTION
## Summary
- add a BuildContext extension returning AppLocalizations
- import this extension in widgets and screens that use `context.loc`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522f8434fc83299f545725ecc6c7f8