### PR TITLE
Fix localized labels in tab bar order screen

### DIFF
--- a/lib/features/settings/presentation/screens/select_tab_bar_order_screen.dart
+++ b/lib/features/settings/presentation/screens/select_tab_bar_order_screen.dart
@@ -55,7 +55,7 @@ class _SelectTabBarOrderScreenState extends State<SelectTabBarOrderScreen> {
             margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
             child: ListTile(
               leading: Icon(item.icon),
-              title: Text(context.loc.item.label),
+              title: Text(_localizedLabel(context, item.label)),
               trailing: const Icon(Icons.drag_handle), // Drag handle icon
             ),
           );
@@ -63,5 +63,22 @@ class _SelectTabBarOrderScreenState extends State<SelectTabBarOrderScreen> {
         onReorder: _onReorder,
       ),
     );
+  }
+
+  String _localizedLabel(BuildContext context, String labelKey) {
+    switch (labelKey) {
+      case 'contacts':
+        return context.loc.contacts;
+      case 'search':
+        return context.loc.search;
+      case 'events':
+        return context.loc.events;
+      case 'photos':
+        return context.loc.photos;
+      case 'settings':
+        return context.loc.settings;
+      default:
+        return labelKey;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- fix dynamic label lookup in select tab bar order screen

## Testing
- `flutter format lib/features/settings/presentation/screens/select_tab_bar_order_screen.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685230ee60e88329866739ecde1347a3