### PR TITLE
Fix Contact constructor usage

### DIFF
--- a/lib/features/events/data/models/event_model.dart
+++ b/lib/features/events/data/models/event_model.dart
@@ -85,7 +85,11 @@ class AppEvent {
         .map(
           (id) => allDeviceContacts.firstWhere(
             (contact) => contact.identifier == id,
-            orElse: () => Contact(identifier: id, givenName: 'Unknown Contact'),
+            orElse: () {
+              final c = Contact(givenName: 'Unknown Contact');
+              c.identifier = id;
+              return c;
+            },
           ),
         )
         .toList();

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -90,8 +90,12 @@ class _SearchScreenState extends State<SearchScreen> {
             final data = doc.data();
             final contactId = doc.reference.parent.parent!.id;
             final contact = _allContacts.firstWhere(
-              (c) => c.id == contactId,
-              orElse: () => Contact(id: contactId, displayName: 'Unknown'),
+              (c) => c.identifier == contactId,
+              orElse: () {
+                final c = Contact(displayName: 'Unknown');
+                c.identifier = contactId;
+                return c;
+              },
             );
             return _FileResult(
               id: doc.id,
@@ -112,8 +116,12 @@ class _SearchScreenState extends State<SearchScreen> {
             final data = doc.data();
             final contactId = doc.reference.parent.parent!.id;
             final contact = _allContacts.firstWhere(
-              (c) => c.id == contactId,
-              orElse: () => Contact(id: contactId, displayName: 'Unknown'),
+              (c) => c.identifier == contactId,
+              orElse: () {
+                final c = Contact(displayName: 'Unknown');
+                c.identifier = contactId;
+                return c;
+              },
             );
             return _NoteResult(
               id: doc.id,


### PR DESCRIPTION
## Summary
- avoid undefined parameter `identifier` when creating unknown Contacts
- update search screen to match constructor expectations

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852558d10a4832998e9862a72b96a6d