### PR TITLE
Fix missing dart typed_data imports

### DIFF
--- a/lib/features/contacts/presentation/screens/add_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/add_contact_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';

--- a/lib/features/contacts/presentation/screens/edit_contact_screen.dart
+++ b/lib/features/contacts/presentation/screens/edit_contact_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:typed_data';
 import 'package:flutter_contacts_service/flutter_contacts_service.dart';
 import 'package:contactsafe/models/contact_labels.dart';
 import 'package:image_picker/image_picker.dart';

--- a/lib/features/settings/controller/settings_controller.dart
+++ b/lib/features/settings/controller/settings_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:contactsafe/shared/widgets/navigation_item.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_contacts_service/flutter_contacts_service.dart';


### PR DESCRIPTION
## Summary
- add `dart:typed_data` imports for contact screens and settings controller

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a5d475188329b78b512b633884f6